### PR TITLE
Updates for the TensorRT RTX EP. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,13 @@ if(MSVC)
     
     # Enable Control Flow Guard for linker as well
     add_link_options(/guard:cf)
+
+    # RelWithDebInfo: disable incremental linking and enable dead-code stripping
+    # to keep DLL size close to Release while retaining debug symbols in the PDB.
+    string(REPLACE "/INCREMENTAL" "/INCREMENTAL:NO"
+        CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO}")
+    set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO
+        "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} /OPT:REF /OPT:ICF")
 endif()
 
 # Find CUDA Toolkit (required)
@@ -213,17 +220,25 @@ message(STATUS "TensorRT ONNX Parser library: ${TRT_ONNX_PARSER_LIB}")
 # =============================================================================
 # External Dependencies (FetchContent)
 # =============================================================================
-include(FetchContent)
+option(USE_VCPKG "use vcpkg package manager" OFF)
 
-# Add ONNX
-FetchContent_Declare(
-    onnx
-    GIT_REPOSITORY https://github.com/onnx/onnx.git
-    GIT_TAG        v1.18.0
-)
-FetchContent_MakeAvailable(onnx)
+if(USE_VCPKG MATCHES "OFF")
+    include(FetchContent)
 
-set(DEPS_PATH "${CMAKE_BINARY_DIR}/_deps")
+    # Add ONNX
+    FetchContent_Declare(
+        onnx
+        GIT_REPOSITORY https://github.com/onnx/onnx.git
+#        GIT_TAG        v1.21.0
+        GIT_TAG        v1.18.0
+    )
+    FetchContent_MakeAvailable(onnx)
+
+    set(DEPS_PATH "${CMAKE_BINARY_DIR}/_deps")
+else()
+    find_package(protobuf CONFIG REQUIRED)
+    find_package(ONNX CONFIG REQUIRED)
+endif()
 
 # =============================================================================
 # Build Configuration Options
@@ -234,13 +249,14 @@ option(TRT_RTX_EP_PRODUCTION_BUILD "Enable production build with signature verif
 # Platform-Specific Configuration
 # =============================================================================
 if(WIN32)
-    # Use generator expressions for multi-config generators (e.g., Visual Studio)
-    # where CMAKE_BUILD_TYPE is empty at configure time
-    set(DEPS_LIBS
-        "${DEPS_PATH}/onnx-build/$<CONFIG>/onnx.lib"
-        "${DEPS_PATH}/onnx-build/$<CONFIG>/onnx_proto.lib"
-    )
-
+    if(USE_VCPKG MATCHES "OFF")
+        # # Use generator expressions for multi-config generators (e.g., Visual Studio)
+        # # where CMAKE_BUILD_TYPE is empty at configure time
+        set(DEPS_LIBS
+            "${DEPS_PATH}/onnx-build/$<CONFIG>/onnx.lib"
+            "${DEPS_PATH}/onnx-build/$<CONFIG>/onnx_proto.lib"
+        )
+    endif()
     set(TRT_EP_LIB_LINK_FLAG "-DEF:${CMAKE_SOURCE_DIR}/src/tensorrt_rtx_execution_provider.def")
 
     # =============================================================================
@@ -261,11 +277,13 @@ if(WIN32)
     # Add delay load linker flags
     set(TRT_EP_LIB_LINK_FLAG "${TRT_EP_LIB_LINK_FLAG} /DELAYLOAD:${TRT_RTX_DLL_NAME} /DELAYLOAD:${TRT_ONNX_PARSER_DLL_NAME}")
 else()
-    # Linux
-    set(DEPS_LIBS
-        "${DEPS_PATH}/onnx-build/libonnx.a"
-        "${DEPS_PATH}/onnx-build/libonnx_proto.a"
-    )
+    if(USE_VCPKG MATCHES "OFF")
+        # # Linux
+        set(DEPS_LIBS
+            "${DEPS_PATH}/onnx-build/libonnx.a"
+            "${DEPS_PATH}/onnx-build/libonnx_proto.a"
+        )
+    endif()
 endif()
 
 # =============================================================================
@@ -275,6 +293,20 @@ if(WIN32)
     add_library(TensorRTRtxEp SHARED ${TRT_RTX_EP_SOURCES} ${TRT_RTX_EP_HEADERS} ${TRT_RTX_EP_VERSION_RC})
 else()
     add_library(TensorRTRtxEp SHARED ${TRT_RTX_EP_SOURCES} ${TRT_RTX_EP_HEADERS})
+endif()
+
+# LTCG (Link-Time Code Generation) for whole-program optimization, scoped to
+# TensorRTRtxEp only so FetchContent dependencies (protobuf, onnx, ...) are not
+# affected. /GL at compile time must be paired with /LTCG at link time.
+if(MSVC)
+    target_compile_options(TensorRTRtxEp PRIVATE
+        $<$<CONFIG:Release>:/GL>
+        $<$<CONFIG:RelWithDebInfo>:/GL>
+    )
+    target_link_options(TensorRTRtxEp PRIVATE
+        $<$<CONFIG:Release>:/LTCG>
+        $<$<CONFIG:RelWithDebInfo>:/LTCG>
+    )
 endif()
 
 # Target compile definitions (modern CMake - replaces add_definitions)
@@ -316,12 +348,17 @@ target_include_directories(TensorRTRtxEp PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
     ${CMAKE_CURRENT_SOURCE_DIR}/src/utils
     ${CMAKE_CURRENT_SOURCE_DIR}/src/kernels
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    "${DEPS_PATH}/onnx-src"
-    "${DEPS_PATH}/onnx-build"
-    "${DEPS_PATH}/protobuf-src/src"
-    "${DEPS_PATH}/abseil-src"
+    ${CMAKE_CURRENT_SOURCE_DIR}   
 )
+
+if (USE_VCPKG MATCHES "OFF")
+    target_include_directories(TensorRTRtxEp PRIVATE
+        "${DEPS_PATH}/onnx-src"
+        "${DEPS_PATH}/onnx-build"
+        "${DEPS_PATH}/protobuf-src/src"
+        "${DEPS_PATH}/abseil-src"
+    )
+endif()
 
 # Link libraries
 target_link_libraries(TensorRTRtxEp PRIVATE
@@ -363,4 +400,15 @@ if(WIN32)
     set_target_properties(TensorRTRtxEp PROPERTIES
         LINK_FLAGS ${TRT_EP_LIB_LINK_FLAG}
     )
+endif()
+
+# =============================================================================
+# Tests
+# =============================================================================
+# enable_testing() must be called unconditionally at the root level so CMake
+# always generates CTestTestfile.cmake here (required for `ctest` to find tests).
+enable_testing()
+option(BUILD_TESTS "Build tests" ON)
+if(BUILD_TESTS)
+    add_subdirectory(tests)
 endif()

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ The TensorRT RTX EP leverages NVIDIA's [TensorRT for RTX](https://developer.nvid
 
 ### Prerequisites
 
-| Dependency | Minimum Version | Platform |
-|------------|-----------------|----------|
-| CMake | 3.15 | All |
-| Visual Studio | 2019 or 2022 (Desktop C++ workload) | Windows |
-| GCC / Clang | C++17-capable | Linux |
-| CUDA Toolkit | 12.9+ | All |
-| ONNX Runtime SDK | 1.24.0+ | All |
-| TensorRT RTX SDK | 1.1.1+ | All |
+| Dependency | Minimum Version | Platform | Notes |
+|------------|-----------------|----------|-------|
+| CMake | 3.15 | All | |
+| Visual Studio | 2019 or 2022 (Desktop C++ workload) | Windows | |
+| GCC / Clang | C++17-capable | Linux | |
+| CUDA Toolkit | 12.9+ | All | |
+| ONNX Runtime SDK | 1.24.0+ | All | |
+| TensorRT RTX SDK | 1.1.1+ | All | |
 
 ### Quick Build
 
@@ -64,7 +64,22 @@ cmake -B build -G "Visual Studio 17 2022" -A x64 `
 cmake --build build --config Release
 ```
 
-Note: If you already have protobuf installed on your system from e.g. `winget` this will conflict with cmake and fail the configuration. 
+Note: If you already have protobuf installed on your system from e.g. `winget` this will conflict with cmake and fail the configuration.
+
+**Windows with vcpkg Package Manager**
+
+vcpkg can optionally be used to manage dependencies (protobuf, ONNX, abseil) instead of CMake FetchContent.
+
+```powershell
+cmake -B build -G "Visual Studio 17 2022" -A x64 `
+      -DONNXRUNTIME_ROOT="C:\SDK\onnxruntime-win-x64-1.24.0" `
+      -DTRT_RTX_ROOT="C:\SDK\TensorRT-RTX-1.1.1.36" `
+      -DUSE_VCPKG=ON `
+      -DCMAKE_TOOLCHAIN_FILE="..\vcpkg\scripts\buildsystems\vcpkg.cmake" `
+      -DVCPKG_TARGET_TRIPLET=x64-windows-static-md `
+      -DVCPKG_HOST_TRIPLET=x64-windows
+cmake --build build --config Release
+```
 
 **Linux**
 
@@ -72,6 +87,19 @@ Note: If you already have protobuf installed on your system from e.g. `winget` t
 cmake -B build \
       -DONNXRUNTIME_ROOT=/path/to/onnxruntime \
       -DTRT_RTX_ROOT=/path/to/tensorrt-rtx
+cmake --build build
+```
+
+**Linux with vcpkg Package Manager**
+
+```bash
+cmake -B build \
+      -DONNXRUNTIME_ROOT=/path/to/onnxruntime \
+      -DTRT_RTX_ROOT=/path/to/tensorrt-rtx \
+      -DUSE_VCPKG=ON \
+      -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake \
+      -DVCPKG_TARGET_TRIPLET=x64-linux \
+      -DVCPKG_HOST_TRIPLET=x64-linux
 cmake --build build
 ```
 

--- a/build.bat
+++ b/build.bat
@@ -36,6 +36,11 @@ set "DO_PRODUCTION=0"
 set "TRT_RTX_EP_VERSION="
 set "FLAGS_SPECIFIED=0"
 set "BUILD_FAILED=0"
+set "USE_VCPKG=OFF"
+set "ARCH=x64"
+set "VCPKG_TARGET_TRIPLET="
+set "VCPKG_HOST_TRIPLET="
+set "VCPKG_TOOLCHAIN_FILE="
 
 REM Parse named arguments
 :parse_args
@@ -91,6 +96,14 @@ if /i "%~1"=="--build" (
 )
 if /i "%~1"=="--production" (
     set "DO_PRODUCTION=1"
+    shift
+    goto :parse_args
+)
+if /i "%~1"=="--use_vcpkg" (
+    set "USE_VCPKG=ON"
+    set "VCPKG_TARGET_TRIPLET=x64-windows-static-md"
+    set "VCPKG_HOST_TRIPLET=x64-windows"
+    set "VCPKG_TOOLCHAIN_FILE=..\vcpkg\scripts\buildsystems\vcpkg.cmake"
     shift
     goto :parse_args
 )
@@ -198,6 +211,7 @@ echo   Version:             %TRT_RTX_EP_VERSION%
 echo   Version:             0.0.0 ^(default^)
 )
 )
+echo   Target Architecture: %ARCH%
 echo ============================================================================
 echo.
 
@@ -230,6 +244,31 @@ if "%DO_UPDATE%"=="1" (
             exit /b 1
         )
     )
+
+REM ============================================================================
+REM Step 2.5: Install vcpkg (if requested)
+REM ============================================================================
+if "%USE_VCPKG%"=="ON" (
+    REM Clone vcpkg
+    if not exist "vcpkg" (
+        git clone https://github.com/microsoft/vcpkg.git
+        if !ERRORLEVEL! NEQ 0 (
+            echo ERROR: Failed to clone vcpkg.
+            exit /b 1
+        )
+        REM Init vcpkg
+        pushd "vcpkg"
+        call .\bootstrap-vcpkg.bat
+        if !ERRORLEVEL! NEQ 0 (
+            echo ERROR: Failed to bootstrap vcpkg.
+            popd
+            exit /b 1
+        )
+        REM Return to root
+        popd
+    )  
+)
+
     
     cd /d "%BUILD_DIR%"
     
@@ -244,10 +283,14 @@ if "%DO_UPDATE%"=="1" (
     ) else (
         set "VERSION_FLAG="
     )
-    cmake -G "Visual Studio 17 2022" -A x64 ^
+    cmake -G "Visual Studio 17 2022" -A %ARCH% ^
           -DCUDAToolkit_ROOT="%CUDA_TOOLKIT_PATH%" ^
           -DONNXRUNTIME_ROOT="%ONNXRUNTIME_ROOT%" ^
           -DTRT_RTX_ROOT="%TRT_RTX_ROOT%" ^
+          -DUSE_VCPKG="%USE_VCPKG%" ^
+          -DCMAKE_TOOLCHAIN_FILE=%VCPKG_TOOLCHAIN_FILE% ^
+          -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% ^
+          -DVCPKG_HOST_TRIPLET=%VCPKG_HOST_TRIPLET% ^
           !PRODUCTION_FLAG! ^
           !VERSION_FLAG! ^
           "%SOURCE_DIR%"
@@ -335,6 +378,7 @@ echo   --update                   Run CMake configuration
 echo   --build                    Compile the project
 echo   --version ^<M.m.p^>          Set EP version (e.g. 1.2.3). Required for --production
 echo   --production               Enable production build with signature verification
+echo   --use_vcpkg                Use VCPKG package manager
 echo   -h, --help, /?             Show this help message
 echo.
 echo Build Actions (can be combined, executed in order: clean -^> update -^> build):

--- a/src/clip_bound_compatibility.cc
+++ b/src/clip_bound_compatibility.cc
@@ -1,0 +1,480 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "clip_bound_compatibility.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <limits>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace trt_rtx_ep
+{
+namespace
+{
+
+// Implementation overview:
+//
+// WebNN clamp(minValue/maxValue omitted) means "do not apply that bound".
+// Chromium's ONNX conversion can encode this as Clip with -inf/+inf scalar
+// inputs. That is legal ONNX math, but TRT-RTX imports Clip through an
+// activation-style path where alpha/beta must be finite, so TRT rejects a
+// graph that is otherwise executable.
+//
+// This pass rewrites only the unbounded sides away:
+//   Clip(x, -inf, +inf)       -> Identity(x)
+//   Clip(x, finite_min, +inf) -> Max(x, finite_min)
+//   Clip(x, -inf, finite_max) -> Min(x, finite_max)
+//
+// The pass is intentionally not a general Clip decomposition. If both bounds
+// are finite, native Clip is already the best representation for TRT. If an
+// ONNX optional bound is omitted, the spec-defined default is a finite dtype
+// limit rather than infinity, so that case stays native too. If a bound is
+// dynamic/unknown/non-scalar/NaN or explicitly asks to produce an infinity,
+// preserving the original node is safer than guessing.
+constexpr const char* kExternalMemAddrLocation = "_MEM_ADDR_";
+constexpr const char* kMainOnnxDomain = "";
+constexpr const char* kAiOnnxDomain = "ai.onnx";
+
+enum class BoundKind
+{
+    kMissing,
+    kFinite,
+    kNegativeInfinity,
+    kPositiveInfinity,
+    kOtherNonFinite,
+    kUnknown,
+};
+
+struct TensorDataView
+{
+    const void* data = nullptr;
+    size_t bytes = 0;
+};
+
+size_t GetTensorElementCount(const onnx::TensorProto& tensor)
+{
+    if (tensor.dims_size() == 0)
+    {
+        return 1;
+    }
+
+    size_t count = 1;
+    for (const auto dim : tensor.dims())
+    {
+        if (dim <= 0)
+        {
+            return 0;
+        }
+        count *= static_cast<size_t>(dim);
+    }
+    return count;
+}
+
+size_t GetTensorElementSize(int32_t data_type)
+{
+    switch (data_type)
+    {
+        case onnx::TensorProto_DataType_FLOAT:
+        case onnx::TensorProto_DataType_INT32:
+        case onnx::TensorProto_DataType_UINT32:
+            return 4;
+        case onnx::TensorProto_DataType_DOUBLE:
+        case onnx::TensorProto_DataType_INT64:
+        case onnx::TensorProto_DataType_UINT64:
+            return 8;
+        case onnx::TensorProto_DataType_FLOAT16:
+        case onnx::TensorProto_DataType_BFLOAT16:
+        case onnx::TensorProto_DataType_INT16:
+        case onnx::TensorProto_DataType_UINT16:
+            return 2;
+        case onnx::TensorProto_DataType_INT8:
+        case onnx::TensorProto_DataType_UINT8:
+        case onnx::TensorProto_DataType_BOOL:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+bool TryGetExternalDataView(const onnx::TensorProto& tensor, TensorDataView& data_view)
+{
+    if (tensor.data_location() != onnx::TensorProto_DataLocation_EXTERNAL)
+    {
+        return false;
+    }
+
+    std::string location;
+    std::string offset;
+    std::string length;
+    for (const auto& entry : tensor.external_data())
+    {
+        if (entry.key() == "location")
+        {
+            location = entry.value();
+        }
+        else if (entry.key() == "offset")
+        {
+            offset = entry.value();
+        }
+        else if (entry.key() == "length")
+        {
+            length = entry.value();
+        }
+    }
+
+    if (location != kExternalMemAddrLocation || offset.empty())
+    {
+        return false;
+    }
+
+    try
+    {
+        const uintptr_t ptr_value = static_cast<uintptr_t>(std::stoull(offset));
+        data_view.data = reinterpret_cast<const void*>(ptr_value);
+        data_view.bytes = length.empty() ? GetTensorElementCount(tensor) * GetTensorElementSize(tensor.data_type())
+                                         : static_cast<size_t>(std::stoull(length));
+    }
+    catch (const std::exception&)
+    {
+        return false;
+    }
+
+    return data_view.data != nullptr && data_view.bytes > 0;
+}
+
+bool TryGetRawDataView(const onnx::TensorProto& tensor, TensorDataView& data_view)
+{
+    data_view = {};
+    if (tensor.has_raw_data())
+    {
+        data_view.data = tensor.raw_data().data();
+        data_view.bytes = static_cast<size_t>(tensor.raw_data().size());
+        return true;
+    }
+
+    return TryGetExternalDataView(tensor, data_view);
+}
+
+template <typename T>
+bool TryReadScalarBytes(const onnx::TensorProto& tensor, T& value)
+{
+    TensorDataView data_view;
+    if (!TryGetRawDataView(tensor, data_view) || data_view.bytes < sizeof(T))
+    {
+        return false;
+    }
+
+    std::memcpy(&value, data_view.data, sizeof(T));
+    return true;
+}
+
+BoundKind ClassifyFloatValue(float value)
+{
+    if (std::isfinite(value))
+    {
+        return BoundKind::kFinite;
+    }
+    if (value == std::numeric_limits<float>::infinity())
+    {
+        return BoundKind::kPositiveInfinity;
+    }
+    if (value == -std::numeric_limits<float>::infinity())
+    {
+        return BoundKind::kNegativeInfinity;
+    }
+    return BoundKind::kOtherNonFinite;
+}
+
+BoundKind ClassifyDoubleValue(double value)
+{
+    if (std::isfinite(value))
+    {
+        return BoundKind::kFinite;
+    }
+    if (value == std::numeric_limits<double>::infinity())
+    {
+        return BoundKind::kPositiveInfinity;
+    }
+    if (value == -std::numeric_limits<double>::infinity())
+    {
+        return BoundKind::kNegativeInfinity;
+    }
+    return BoundKind::kOtherNonFinite;
+}
+
+BoundKind ClassifyFloat16Bits(uint16_t bits)
+{
+    const uint16_t exponent = bits & 0x7c00;
+    const uint16_t mantissa = bits & 0x03ff;
+    if (exponent != 0x7c00)
+    {
+        return BoundKind::kFinite;
+    }
+    if (mantissa != 0)
+    {
+        return BoundKind::kOtherNonFinite;
+    }
+    return (bits & 0x8000) ? BoundKind::kNegativeInfinity : BoundKind::kPositiveInfinity;
+}
+
+BoundKind ClassifyBFloat16Bits(uint16_t bits)
+{
+    const uint16_t exponent = bits & 0x7f80;
+    const uint16_t mantissa = bits & 0x007f;
+    if (exponent != 0x7f80)
+    {
+        return BoundKind::kFinite;
+    }
+    if (mantissa != 0)
+    {
+        return BoundKind::kOtherNonFinite;
+    }
+    return (bits & 0x8000) ? BoundKind::kNegativeInfinity : BoundKind::kPositiveInfinity;
+}
+
+BoundKind ClassifyScalarTensor(const onnx::TensorProto& tensor)
+{
+    // Policy: only rewrite bounds that are compile-time scalar constants.
+    // Dynamic, vector, or unreadable bounds may carry user/runtime semantics
+    // that cannot be proven equivalent here, so they stay native and let TRT
+    // make the final parser decision.
+    if (GetTensorElementCount(tensor) != 1)
+    {
+        return BoundKind::kUnknown;
+    }
+
+    switch (tensor.data_type())
+    {
+        case onnx::TensorProto_DataType_FLOAT:
+        {
+            float value = 0.0f;
+            if (TryReadScalarBytes(tensor, value))
+            {
+                return ClassifyFloatValue(value);
+            }
+            return tensor.float_data_size() == 1 ? ClassifyFloatValue(tensor.float_data(0)) : BoundKind::kUnknown;
+        }
+        case onnx::TensorProto_DataType_DOUBLE:
+        {
+            double value = 0.0;
+            if (TryReadScalarBytes(tensor, value))
+            {
+                return ClassifyDoubleValue(value);
+            }
+            return tensor.double_data_size() == 1 ? ClassifyDoubleValue(tensor.double_data(0)) : BoundKind::kUnknown;
+        }
+        case onnx::TensorProto_DataType_FLOAT16:
+        {
+            uint16_t bits = 0;
+            if (TryReadScalarBytes(tensor, bits))
+            {
+                return ClassifyFloat16Bits(bits);
+            }
+            return tensor.int32_data_size() == 1 ? ClassifyFloat16Bits(static_cast<uint16_t>(tensor.int32_data(0)))
+                                                 : BoundKind::kUnknown;
+        }
+        case onnx::TensorProto_DataType_BFLOAT16:
+        {
+            uint16_t bits = 0;
+            if (TryReadScalarBytes(tensor, bits))
+            {
+                return ClassifyBFloat16Bits(bits);
+            }
+            return tensor.int32_data_size() == 1 ? ClassifyBFloat16Bits(static_cast<uint16_t>(tensor.int32_data(0)))
+                                                 : BoundKind::kUnknown;
+        }
+        case onnx::TensorProto_DataType_INT8:
+        case onnx::TensorProto_DataType_UINT8:
+        case onnx::TensorProto_DataType_INT16:
+        case onnx::TensorProto_DataType_UINT16:
+        case onnx::TensorProto_DataType_INT32:
+        case onnx::TensorProto_DataType_UINT32:
+        case onnx::TensorProto_DataType_INT64:
+        case onnx::TensorProto_DataType_UINT64:
+            return BoundKind::kFinite;
+        default:
+            return BoundKind::kUnknown;
+    }
+}
+
+const onnx::TensorProto* FindConstantTensorAttribute(const onnx::NodeProto& node)
+{
+    if (node.op_type() != "Constant" ||
+        (!node.domain().empty() && node.domain() != kMainOnnxDomain && node.domain() != kAiOnnxDomain))
+    {
+        return nullptr;
+    }
+
+    for (const auto& attr : node.attribute())
+    {
+        if (attr.name() == "value" && attr.type() == onnx::AttributeProto_AttributeType_TENSOR)
+        {
+            return &attr.t();
+        }
+    }
+    return nullptr;
+}
+
+bool HasLegacyClipBoundsAttributes(const onnx::NodeProto& node)
+{
+    for (const auto& attr : node.attribute())
+    {
+        if (attr.name() == "min" || attr.name() == "max")
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+struct GraphIndex
+{
+    explicit GraphIndex(const onnx::GraphProto& graph_proto)
+    {
+        for (const auto& initializer : graph_proto.initializer())
+        {
+            initializers[initializer.name()] = &initializer;
+        }
+
+        for (int node_index = 0; node_index < graph_proto.node_size(); ++node_index)
+        {
+            const auto& node = graph_proto.node(node_index);
+            for (const auto& output : node.output())
+            {
+                if (!output.empty())
+                {
+                    producers[output] = &node;
+                }
+            }
+        }
+    }
+
+    BoundKind ResolveBound(const onnx::NodeProto& node, int input_index) const
+    {
+        // ONNX Clip input 1 is min and input 2 is max. Missing optional
+        // inputs are not the same as explicit +/-infinity constants: ONNX
+        // defines omitted bounds as finite dtype limits, so those cases must
+        // stay native unless we explicitly materialize the finite default.
+        if (node.input_size() <= input_index || node.input(input_index).empty())
+        {
+            return BoundKind::kMissing;
+        }
+
+        // WebNN-generated models usually materialize clamp bounds either as
+        // graph initializers or Constant nodes. We intentionally do not chase
+        // through arithmetic, casts, or other producers because that would turn
+        // this parser-compat pass into partial constant propagation.
+        const auto& input_name = node.input(input_index);
+        const auto initializer_it = initializers.find(input_name);
+        if (initializer_it != initializers.end())
+        {
+            return ClassifyScalarTensor(*initializer_it->second);
+        }
+
+        const auto producer_it = producers.find(input_name);
+        if (producer_it != producers.end())
+        {
+            if (const auto* tensor = FindConstantTensorAttribute(*producer_it->second))
+            {
+                return ClassifyScalarTensor(*tensor);
+            }
+        }
+
+        return BoundKind::kUnknown;
+    }
+
+    std::unordered_map<std::string, const onnx::TensorProto*> initializers;
+    std::unordered_map<std::string, const onnx::NodeProto*> producers;
+};
+
+bool IsLowerUnbounded(BoundKind kind)
+{
+    // Only explicit WebNN-style -inf is unbounded for this rewrite. A missing
+    // ONNX Clip min input means the finite lowest value for the input dtype,
+    // which is observably different for -inf inputs.
+    return kind == BoundKind::kNegativeInfinity;
+}
+
+bool IsUpperUnbounded(BoundKind kind)
+{
+    // Only explicit WebNN-style +inf is unbounded for this rewrite. A missing
+    // ONNX Clip max input means the finite max value for the input dtype, which
+    // is observably different for +inf inputs.
+    return kind == BoundKind::kPositiveInfinity;
+}
+
+void ReplaceNode(onnx::NodeProto& node, const std::string& op_type, const std::vector<std::string>& inputs)
+{
+    // Keep the original output name and doc_string. Downstream edges and the
+    // provider's proto-node bookkeeping still see the same logical node result;
+    // only the parser-hostile Clip opcode/inputs are changed.
+    node.set_op_type(op_type);
+    node.clear_attribute();
+    node.mutable_input()->Clear();
+    for (const auto& input : inputs)
+    {
+        node.add_input(input);
+    }
+}
+
+void RewriteClipBounds(onnx::GraphProto& graph)
+{
+    const GraphIndex index(graph);
+
+    for (auto& node : *graph.mutable_node())
+    {
+        if (node.op_type() != "Clip" ||
+            (!node.domain().empty() && node.domain() != kMainOnnxDomain && node.domain() != kAiOnnxDomain) ||
+            node.input_size() < 1 || node.input(0).empty() || node.output_size() != 1)
+        {
+            continue;
+        }
+
+        // Older ONNX Clip opsets encoded min/max as attributes instead of
+        // optional inputs. Missing input 1/2 is unbounded only for modern
+        // input-form Clip, so leave legacy attribute-form Clip untouched.
+        if (HasLegacyClipBoundsAttributes(node))
+        {
+            continue;
+        }
+
+        const auto lower_bound = index.ResolveBound(node, 1);
+        const auto upper_bound = index.ResolveBound(node, 2);
+
+        // Safe rewrites only for explicit +/-inf bounds:
+        //   * explicit -inf lower and +inf upper -> Identity
+        //   * finite lower and explicit +inf     -> Max
+        //   * explicit -inf and finite upper     -> Min
+        //
+        // Missing ONNX Clip bounds, explicit non-finite producing cases such
+        // as min=+inf/max=-inf, NaN bounds, or unknown dynamic bounds are
+        // intentionally left untouched.
+        if (IsLowerUnbounded(lower_bound) && IsUpperUnbounded(upper_bound))
+        {
+            ReplaceNode(node, "Identity", {node.input(0)});
+        }
+        else if (lower_bound == BoundKind::kFinite && IsUpperUnbounded(upper_bound))
+        {
+            ReplaceNode(node, "Max", {node.input(0), node.input(1)});
+        }
+        else if (IsLowerUnbounded(lower_bound) && upper_bound == BoundKind::kFinite)
+        {
+            ReplaceNode(node, "Min", {node.input(0), node.input(2)});
+        }
+    }
+}
+
+}  // namespace
+
+void RunClipBoundCompatibilityForTensorRt(onnx::ModelProto& model_proto)
+{
+    RewriteClipBounds(*model_proto.mutable_graph());
+}
+
+}  // namespace trt_rtx_ep

--- a/src/clip_bound_compatibility.h
+++ b/src/clip_bound_compatibility.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "onnx/onnx_pb.h"
+
+namespace trt_rtx_ep
+{
+
+// Rewrites ONNX Clip nodes that use WebNN's unbounded clamp defaults into
+// parser-friendly ONNX nodes before TRT-RTX sees the proto.
+//
+// WebNN clamp with an omitted min/max means "no lower/upper clamp". Chromium's
+// ONNX lowering can represent that as Clip bounds of -inf/+inf, but TRT-RTX's
+// parser maps Clip to activation alpha/beta parameters that must be finite.
+//
+// Safe rewrites:
+//   Clip(x, -inf, +inf)       -> Identity(x)
+//   Clip(x, finite_min, +inf) -> Max(x, finite_min)
+//   Clip(x, -inf, finite_max) -> Min(x, finite_max)
+//
+// Missing ONNX Clip bounds default to finite dtype limits, not infinity, so
+// they are intentionally left untouched. Explicit cases that would need to
+// produce infinities, such as min=+inf or max=-inf, are also left untouched.
+void RunClipBoundCompatibilityForTensorRt(onnx::ModelProto& model_proto);
+
+}  // namespace trt_rtx_ep

--- a/src/ep_arena.cc
+++ b/src/ep_arena.cc
@@ -43,6 +43,13 @@ ArenaImpl::ArenaImpl(AllocatorUniquePtr<OrtAllocator> allocator, const ArenaConf
 
   stats_.bytes_limit = static_cast<int64_t>(config.max_mem);
 
+  // kSameAsRequested: consider all regions (including the first) for shrinkage since the initial
+  // chunk size is irrelevant and the arena only extends by the exact request size.
+  // kNextPowerOfTwo: keep the first region to preserve the user's chosen initial allocation and
+  // avoid unnecessary re-growth.
+  consider_first_allocation_region_for_shrinkage_ =
+      (config_.arena_extend_strategy == ArenaExtendStrategy::kSameAsRequested);
+
   // Create a bunch of bins of various good sizes.
 
   // We create bins to fit all possible ranges that cover the
@@ -776,6 +783,68 @@ OrtStatus* ArenaImpl::ResetChunksUsingStream(const OrtSyncStreamImpl* stream_imp
       h = c->next;
     }
   }
+
+  return nullptr;
+}
+
+OrtStatus* ArenaImpl::Shrink() {
+  std::lock_guard<std::mutex> lock(lock_);
+
+  auto num_regions = region_manager_.regions().size();
+  std::vector<void*> region_ptrs;
+  std::vector<size_t> region_sizes;
+  region_ptrs.reserve(num_regions);
+  region_sizes.reserve(num_regions);
+
+  for (const auto& region : region_manager_.regions()) {
+    if (consider_first_allocation_region_for_shrinkage_ || region.id() != 0) {
+      region_ptrs.push_back(region.ptr());
+      region_sizes.push_back(region.memory_size());
+    }
+  }
+
+  size_t i = 0;
+  for (void* region_ptr : region_ptrs) {
+    bool deallocate_region = true;
+    ChunkHandle region_begin_chunk = region_manager_.get_handle(region_ptr);
+    ChunkHandle h = region_begin_chunk;
+    while (h != kInvalidChunkHandle) {
+      const Chunk* c = ChunkFromHandle(h);
+      if (c->in_use()) {
+        deallocate_region = false;
+        break;
+      }
+      h = c->next;
+    }
+
+    if (deallocate_region) {
+      auto shrink_size = region_sizes[i];
+      stats_.num_arena_shrinkages += 1;
+      stats_.total_allocated_bytes -= shrink_size;
+
+      LOG(VERBOSE, allocator_name_ << " Arena shrunk by " << shrink_size << " bytes."
+                                   << " The total allocated bytes is now " << stats_.total_allocated_bytes);
+
+      h = region_begin_chunk;
+      ChunkHandle temp = region_begin_chunk;
+      while (h != kInvalidChunkHandle) {
+        const Chunk* c = ChunkFromHandle(h);
+        temp = c->next;
+        RemoveFreeChunkFromBin(h);
+        DeleteChunk(h);
+        h = temp;
+      }
+
+      device_allocator_->Free(device_allocator_.get(), region_ptr);
+      region_manager_.RemoveAllocationRegion(region_ptr);
+      stats_.num_arena_extensions--;
+    }
+
+    ++i;
+  }
+
+  // Reset region allocation tracking so the arena can re-grow from the initial growth size
+  curr_region_allocation_bytes_ = config_.initial_growth_chunk_size_bytes;
 
   return nullptr;
 }

--- a/src/ep_arena.h
+++ b/src/ep_arena.h
@@ -209,6 +209,10 @@ class ArenaImpl {
   // usage is asynchronous on the GPU side, and the code assigning memory is running on CPU prior to that.
   OrtStatus* ResetChunksUsingStream(const OrtSyncStreamImpl* stream_impl);
 
+  // Release unused memory regions back to the device allocator.
+  // Iterates all allocation regions and frees any that contain only free (unused) chunks.
+  OrtStatus* Shrink();
+
  private:
   void* AllocateRawInternal(size_t num_bytes, OrtSyncStream* stream, bool dump_log_on_failure);
   void DeallocateRawInternal(void* ptr);
@@ -600,6 +604,11 @@ class ArenaImpl {
 
   AllocatorStats stats_;
 
+  // If true, the first allocation region is eligible for shrinkage.
+  // kSameAsRequested: all regions (including first) can be shrunk.
+  // kNextPowerOfTwo: the first region is kept to avoid re-growing from scratch.
+  bool consider_first_allocation_region_for_shrinkage_;
+
   const OrtApi& api_;
   const OrtEpApi& ep_api_;
   const OrtLogger& logger_;
@@ -643,6 +652,13 @@ struct ArenaAllocator : OrtAllocator {
     Info = InfoImpl;
     GetStats = GetStatsImpl;
     AllocOnStream = nullptr;
+#if defined(ORT_API_VERSION) && ORT_API_VERSION >= 25
+    // OrtAllocator::Shrink was added in ORT 1.25 (ORT_API_VERSION 25).
+    // When building against older headers the field does not exist, so the
+    // assignment is compiled out. Callers on older runtimes never invoke
+    // arena shrinkage via this path.
+    Shrink = ShrinkImpl;
+#endif
   }
 
   // remove the OrtSyncStream* from any chunks that were using the stream
@@ -680,6 +696,11 @@ struct ArenaAllocator : OrtAllocator {
     const auto& arena = *static_cast<const ArenaAllocator*>(this_);
     return arena.impl_->GetStats(out);
   };
+
+  static OrtStatus* ORT_API_CALL ShrinkImpl(struct OrtAllocator* this_) noexcept {
+    auto& arena = *static_cast<ArenaAllocator*>(this_);
+    return arena.impl_->Shrink();
+  }
 
  private:
   std::unique_ptr<ArenaImpl> impl_;

--- a/src/logical_output_compatibility.cc
+++ b/src/logical_output_compatibility.cc
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "logical_output_compatibility.h"
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace trt_rtx_ep
+{
+namespace
+{
+
+struct TensorMetadata
+{
+    std::optional<int32_t> element_type;
+};
+
+struct GraphIndex
+{
+    explicit GraphIndex(const onnx::GraphProto& graph_proto)
+        : graph(graph_proto)
+    {
+        Build();
+    }
+
+    const onnx::NodeProto* GetNode(size_t index) const
+    {
+        if (index >= static_cast<size_t>(graph.node_size()))
+        {
+            return nullptr;
+        }
+        return &graph.node(static_cast<int>(index));
+    }
+
+    const onnx::NodeProto* FindProducer(const std::string& name) const
+    {
+        const auto it = producer_node_indices.find(name);
+        return it == producer_node_indices.end() ? nullptr : GetNode(it->second);
+    }
+
+    const std::vector<size_t>* FindConsumerNodeIndices(const std::string& name) const
+    {
+        const auto it = consumer_node_indices.find(name);
+        return it == consumer_node_indices.end() ? nullptr : &it->second;
+    }
+
+    std::optional<int32_t> FindTensorElementType(const std::string& name) const
+    {
+        const auto it = tensor_metadata.find(name);
+        if (it == tensor_metadata.end())
+        {
+            return std::nullopt;
+        }
+        return it->second.element_type;
+    }
+
+    const onnx::GraphProto& graph;
+    std::unordered_map<std::string, TensorMetadata> tensor_metadata;
+    std::unordered_map<std::string, size_t> producer_node_indices;
+    std::unordered_map<std::string, std::vector<size_t>> consumer_node_indices;
+
+private:
+    void Build()
+    {
+        for (const auto& value_info : graph.input())
+        {
+            AddValueInfo(value_info);
+        }
+        for (const auto& value_info : graph.value_info())
+        {
+            AddValueInfo(value_info);
+        }
+        for (const auto& value_info : graph.output())
+        {
+            AddValueInfo(value_info);
+        }
+
+        for (int node_index = 0; node_index < graph.node_size(); ++node_index)
+        {
+            const auto& node = graph.node(node_index);
+            for (const auto& input_name : node.input())
+            {
+                if (!input_name.empty())
+                {
+                    consumer_node_indices[input_name].push_back(static_cast<size_t>(node_index));
+                }
+            }
+            for (const auto& output_name : node.output())
+            {
+                if (!output_name.empty())
+                {
+                    producer_node_indices[output_name] = static_cast<size_t>(node_index);
+                }
+            }
+        }
+    }
+
+    void AddValueInfo(const onnx::ValueInfoProto& value_info)
+    {
+        if (!value_info.has_type() || !value_info.type().has_tensor_type())
+        {
+            return;
+        }
+
+        tensor_metadata[value_info.name()].element_type = value_info.type().tensor_type().elem_type();
+    }
+};
+
+std::optional<int64_t> FindIntAttribute(const onnx::NodeProto& node, const std::string& name)
+{
+    for (const auto& attr : node.attribute())
+    {
+        if (attr.name() == name && attr.type() == onnx::AttributeProto_AttributeType_INT)
+        {
+            return attr.i();
+        }
+    }
+    return std::nullopt;
+}
+
+onnx::AttributeProto* FindMutableAttribute(onnx::NodeProto& node, const std::string& name)
+{
+    for (auto& attribute : *node.mutable_attribute())
+    {
+        if (attribute.name() == name)
+        {
+            return &attribute;
+        }
+    }
+    return nullptr;
+}
+
+void UpdateTensorElementType(google::protobuf::RepeatedPtrField<onnx::ValueInfoProto>* value_infos,
+                             const std::string& tensor_name, int32_t element_type)
+{
+    for (auto& value_info : *value_infos)
+    {
+        if (value_info.name() != tensor_name)
+        {
+            continue;
+        }
+
+        value_info.mutable_type()->mutable_tensor_type()->set_elem_type(element_type);
+    }
+}
+
+bool IsKnownBoolProducer(const onnx::NodeProto& node)
+{
+    return node.op_type() == "Equal" || node.op_type() == "NotEqual" || node.op_type() == "Greater" ||
+           node.op_type() == "GreaterOrEqual" || node.op_type() == "Less" || node.op_type() == "LessOrEqual" ||
+           node.op_type() == "And" || node.op_type() == "Or" || node.op_type() == "Xor" || node.op_type() == "Not" ||
+           node.op_type() == "IsInf" || node.op_type() == "IsNaN";
+}
+
+bool IsBoolTensor(const GraphIndex& index, const std::string& tensor_name)
+{
+    const auto tensor_type = index.FindTensorElementType(tensor_name);
+    if (tensor_type.has_value())
+    {
+        return *tensor_type == onnx::TensorProto_DataType_BOOL;
+    }
+
+    const auto* producer = index.FindProducer(tensor_name);
+    return producer != nullptr && IsKnownBoolProducer(*producer);
+}
+
+// Canonicalize Chromium's bool -> uint8 -> Cast(T) bridge to
+// bool -> Cast(int32) -> Cast(T) when every downstream use is already a cast.
+// This removes the unsupported UINT8 intermediate while keeping a single
+// parser-friendly bridge type that can fan out to different final cast types.
+void CanonicalizeBoolBridgeCastChain(onnx::GraphProto& graph)
+{
+    const GraphIndex index(graph);
+
+    std::unordered_set<std::string> graph_outputs;
+    for (const auto& output : graph.output())
+    {
+        if (!output.name().empty())
+        {
+            graph_outputs.insert(output.name());
+        }
+    }
+
+    for (int node_index = 0; node_index < graph.node_size(); ++node_index)
+    {
+        auto* uint8_bridge = graph.mutable_node(node_index);
+        if (uint8_bridge->op_type() != "Cast" || uint8_bridge->input_size() != 1 || uint8_bridge->output_size() != 1 ||
+            uint8_bridge->input(0).empty() || uint8_bridge->output(0).empty())
+        {
+            continue;
+        }
+
+        const auto bridge_type = FindIntAttribute(*uint8_bridge, "to");
+        if (!bridge_type || *bridge_type != onnx::TensorProto_DataType_UINT8)
+        {
+            continue;
+        }
+
+        if (graph_outputs.find(uint8_bridge->output(0)) != graph_outputs.end())
+        {
+            continue;
+        }
+
+        if (!IsBoolTensor(index, uint8_bridge->input(0)))
+        {
+            continue;
+        }
+
+        const auto* consumer_indices = index.FindConsumerNodeIndices(uint8_bridge->output(0));
+        if (consumer_indices == nullptr || consumer_indices->empty())
+        {
+            continue;
+        }
+
+        bool can_retarget_bridge = true;
+        for (const size_t consumer_index : *consumer_indices)
+        {
+            const auto* consumer = index.GetNode(consumer_index);
+            if (consumer == nullptr || consumer->op_type() != "Cast" || consumer->input_size() != 1 ||
+                consumer->input(0) != uint8_bridge->output(0))
+            {
+                can_retarget_bridge = false;
+                break;
+            }
+
+            const auto consumer_type = FindIntAttribute(*consumer, "to");
+            if (!consumer_type || *consumer_type == onnx::TensorProto_DataType_UINT8)
+            {
+                can_retarget_bridge = false;
+                break;
+            }
+        }
+
+        if (!can_retarget_bridge)
+        {
+            continue;
+        }
+
+        auto* bridge_attr = FindMutableAttribute(*uint8_bridge, "to");
+        if (bridge_attr == nullptr)
+        {
+            continue;
+        }
+
+        bridge_attr->set_i(onnx::TensorProto_DataType_INT32);
+        UpdateTensorElementType(graph.mutable_value_info(), uint8_bridge->output(0), onnx::TensorProto_DataType_INT32);
+        UpdateTensorElementType(graph.mutable_output(), uint8_bridge->output(0), onnx::TensorProto_DataType_INT32);
+    }
+}
+
+}  // namespace
+
+void RunLogicalOutputCompatibilityForTensorRt(onnx::ModelProto& model_proto)
+{
+    CanonicalizeBoolBridgeCastChain(*model_proto.mutable_graph());
+}
+
+}  // namespace trt_rtx_ep

--- a/src/logical_output_compatibility.h
+++ b/src/logical_output_compatibility.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "onnx/onnx_pb.h"
+
+namespace trt_rtx_ep
+{
+
+// Canonicalizes bool-output bridge patterns that are legal in the WebNN /
+// Chromium stack but problematic for TRT-RTX's ONNX parser.
+//
+// Chromium currently materializes WebNN logical outputs as:
+//
+//   bool_tensor -> Cast(uint8) -> Cast(T)
+//
+// because ONNX logical ops produce bool while WebNN logical outputs are typed
+// as uint8. TRT-RTX rejects UINT8 as an intermediate tensor on the parser
+// path, even though the graph usually casts that bridge again immediately.
+//
+// This pass canonicalizes the bridge to int32 when doing so is provably
+// semantics-preserving:
+//   * the bridge input is a bool tensor,
+//   * the bridge output is not a graph output,
+//   * every downstream use is a Cast,
+//   * and none of those downstream casts keep the value as uint8.
+//
+// The resulting graph becomes:
+//
+//   bool_tensor -> Cast(int32) -> Cast(T)
+//
+// Canonicalizing to one parser-friendly bridge type keeps the rewrite generic:
+// multiple downstream casts can target different final types while still
+// avoiding the unsupported UINT8 intermediate before TRT sees the serialized
+// proto.
+void RunLogicalOutputCompatibilityForTensorRt(onnx::ModelProto& model_proto);
+
+}  // namespace trt_rtx_ep

--- a/src/onnx_ctx_model_helper.cc
+++ b/src/onnx_ctx_model_helper.cc
@@ -24,6 +24,15 @@
 #include <fstream>
 #include <iostream>
 
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
 namespace trt_rtx_ep
 {
 
@@ -142,6 +151,17 @@ bool IsRelativePathToParentPath(const std::string& path_string)
 //!
 //! \brief Return the directory where the ep context model locates.
 //!
+//! Semantics:
+//!  - If ep_context_file_path ends with a path separator (e.g., "/tmp/out/"),
+//!    it is treated as a directory and returned as-is.
+//!  - Otherwise ep_context_file_path is treated as a file (or file stem), and
+//!    its parent directory is returned. This matches both the SetOutputModelPath
+//!    case (e.g., "dir/model.onnx" -> "dir") and the SetEpContextBinaryInformation
+//!    case (e.g., "dir/stem" -> "dir"). We deliberately do NOT rely on
+//!    std::filesystem::is_directory() here because a same-named directory may
+//!    pre-exist on disk from earlier runs, which would otherwise flip the
+//!    interpretation in a state-dependent way.
+//!
 std::filesystem::path GetPathOrParentPathOfCtxModel(const std::string& ep_context_file_path)
 {
     if (ep_context_file_path.empty())
@@ -149,14 +169,16 @@ std::filesystem::path GetPathOrParentPathOfCtxModel(const std::string& ep_contex
         return std::filesystem::path();
     }
     std::filesystem::path ctx_path(ep_context_file_path);
-    if (std::filesystem::is_directory(ep_context_file_path))
+    const char back = ep_context_file_path.back();
+    // A trailing path separator alone implies directory semantics. We deliberately
+    // do not probe the filesystem here so that interpretation is stable regardless
+    // of whether a same-named directory happens to exist from a previous run.
+    const bool has_trailing_sep = (back == '/' || back == '\\');
+    if (has_trailing_sep)
     {
         return ctx_path;
     }
-    else
-    {
-        return ctx_path.parent_path();
-    }
+    return ctx_path.parent_path();
 }
 
 bool IsWeightStrippedEngineCache(std::filesystem::path& engine_cache_path)
@@ -390,11 +412,16 @@ OrtStatus* EPContextNodeReader::GetEpContextFromGraph(const OrtGraph& graph)
     int64_t embed_mode = 0;
     RETURN_IF_ORT_STATUS_ERROR(node_attr.GetValue(embed_mode));
 
-    // Get "partition_name" (fused node name at build time) for runtime cache path consistency across sessions
+    // Get "partition_name" (fused node name at build time) for runtime cache path consistency across sessions.
+    //
+    // NOTE: The Ort C++ wrapper Node_GetAttributeByName returns IsOK()==true for
+    // attributes that are NOT present, leaving the attr as a null OrtOpAttr*.
+    // Calling GetType() on that null pointer causes an access violation. Guard here.
     partition_name_.clear();
     {
         Ort::ConstOpAttr part_attr;
         if (node.GetAttributeByName(PARTITION_NAME.c_str(), part_attr).IsOK() &&
+            static_cast<const OrtOpAttr*>(part_attr) != nullptr &&
             part_attr.GetType() == OrtOpAttrType::ORT_OP_ATTR_STRING)
         {
             (void)part_attr.GetValue<std::string>(partition_name_);
@@ -465,8 +492,15 @@ OrtStatus* EPContextNodeReader::GetEpContextFromGraph(const OrtGraph& graph)
             return ort_api.CreateStatus(ORT_EP_FAIL, message.c_str());
         }
 
-        // The engine cache and context model (current model) should be in the same directory
-        std::filesystem::path ctx_model_dir(GetPathOrParentPathOfCtxModel(ep_context_model_path_));
+        // The engine cache and context model (current model) should be in the same directory.
+        // When the context model is loaded from a buffer, ep_context_model_path_ is empty,
+        // so there is no model-file location to anchor the relative ep_cache_context path.
+        // Fall back to the ep_context_file_path session option (set via
+        // kOrtSessionOptionEpContextFilePath), which the caller is expected to provide to
+        // locate external engine binaries in that scenario (matches the QNN EP pattern).
+        const std::string& effective_ctx_path =
+            !ep_context_model_path_.empty() ? ep_context_model_path_ : ep_.GetEpContextFilePath();
+        std::filesystem::path ctx_model_dir(GetPathOrParentPathOfCtxModel(effective_ctx_path));
         auto engine_cache_path = ctx_model_dir.append(cache_path);
 
         std::string message = "[TensorRT EP] GetEpContextFromGraph engine_cache_path: " + engine_cache_path.string();
@@ -503,13 +537,65 @@ OrtStatus* EPContextNodeReader::GetEpContextFromGraph(const OrtGraph& graph)
             return ort_api.CreateStatus(ORT_EP_FAIL, error_msg.c_str());
         }
 
-        std::ifstream engine_file(engine_cache_path.string(), std::ios::binary | std::ios::in);
-        engine_file.seekg(0, std::ios::end);
-        size_t engine_size = engine_file.tellg();
-        engine_file.seekg(0, std::ios::beg);
-        std::unique_ptr<char[]> engine_buf{new char[engine_size]};
-        engine_file.read((char*)engine_buf.get(), engine_size);
-        *(trt_rtx_engine_) = std::unique_ptr<nvinfer1::ICudaEngine>(trt_rtx_runtime_->deserializeCudaEngine(engine_buf.get(), engine_size));
+#if defined(_WIN32)
+        HANDLE file_handle = CreateFileW(engine_cache_path.wstring().c_str(),
+                                         GENERIC_READ, FILE_SHARE_READ, nullptr,
+                                         OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, nullptr);
+        if (file_handle == INVALID_HANDLE_VALUE)
+        {
+            std::string error_msg = "TensorRT EP failed to open engine cache: " + engine_cache_path.string();
+            return ort_api.CreateStatus(ORT_EP_FAIL, error_msg.c_str());
+        }
+        LARGE_INTEGER file_size_li{};
+        if (!GetFileSizeEx(file_handle, &file_size_li))
+        {
+            CloseHandle(file_handle);
+            std::string error_msg = "TensorRT EP failed to get size of engine cache: " + engine_cache_path.string();
+            return ort_api.CreateStatus(ORT_EP_FAIL, error_msg.c_str());
+        }
+        const size_t engine_size = static_cast<size_t>(file_size_li.QuadPart);
+        HANDLE mapping_handle = CreateFileMappingW(file_handle, nullptr, PAGE_READONLY, 0, 0, nullptr);
+        const void* mapped_data = (mapping_handle != nullptr)
+                                      ? MapViewOfFile(mapping_handle, FILE_MAP_READ, 0, 0, 0)
+                                      : nullptr;
+        if (!mapped_data)
+        {
+            if (mapping_handle) CloseHandle(mapping_handle);
+            CloseHandle(file_handle);
+            std::string error_msg = "TensorRT EP failed to map engine cache: " + engine_cache_path.string();
+            return ort_api.CreateStatus(ORT_EP_FAIL, error_msg.c_str());
+        }
+        *(trt_rtx_engine_) = std::unique_ptr<nvinfer1::ICudaEngine>(
+            trt_rtx_runtime_->deserializeCudaEngine(mapped_data, engine_size));
+        UnmapViewOfFile(mapped_data);
+        CloseHandle(mapping_handle);
+        CloseHandle(file_handle);
+#else
+        const int fd = ::open(engine_cache_path.c_str(), O_RDONLY);
+        if (fd == -1)
+        {
+            std::string error_msg = "TensorRT EP failed to open engine cache: " + engine_cache_path.string();
+            return ort_api.CreateStatus(ORT_EP_FAIL, error_msg.c_str());
+        }
+        struct stat st{};
+        if (::fstat(fd, &st) == -1)
+        {
+            ::close(fd);
+            std::string error_msg = "TensorRT EP failed to fstat engine cache: " + engine_cache_path.string();
+            return ort_api.CreateStatus(ORT_EP_FAIL, error_msg.c_str());
+        }
+        const size_t engine_size = static_cast<size_t>(st.st_size);
+        void* mapped_data = ::mmap(nullptr, engine_size, PROT_READ, MAP_PRIVATE, fd, 0);
+        ::close(fd);
+        if (mapped_data == MAP_FAILED)
+        {
+            std::string error_msg = "TensorRT EP failed to map engine cache: " + engine_cache_path.string();
+            return ort_api.CreateStatus(ORT_EP_FAIL, error_msg.c_str());
+        }
+        *(trt_rtx_engine_) = std::unique_ptr<nvinfer1::ICudaEngine>(
+            trt_rtx_runtime_->deserializeCudaEngine(mapped_data, engine_size));
+        ::munmap(mapped_data, engine_size);
+#endif
         if (!(*trt_rtx_engine_))
         {
             std::string error_msg = "TensorRT EP could not deserialize engine from cache: " + engine_cache_path.string();

--- a/src/pooling_dilation_compatibility.cc
+++ b/src/pooling_dilation_compatibility.cc
@@ -1,0 +1,597 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pooling_dilation_compatibility.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace trt_rtx_ep
+{
+namespace
+{
+
+// Implementation overview:
+//
+// ONNX/WebNN dilated pooling does not change the number of kernel taps; it
+// changes the spacing between taps. For a 3x3 kernel with dilations=[2,2], the
+// operator samples nine values spread across an effective 5x5 input region.
+// TRT-RTX rejects AveragePool/MaxPool when any dilation is not 1, even though
+// the same math can be expressed with primitive tensor operations.
+//
+// This pass decomposes a supported dilated pool into:
+//   1. One Slice per kernel tap. Each Slice gathers that tap for every output
+//      location using starts = tap * dilation and steps = original strides.
+//   2. AveragePool: add all tap tensors and divide by the number of taps.
+//   3. MaxPool: chain elementwise Max across all tap tensors.
+//
+// Correctness policy: lower only when every window is fully inside the input.
+// That keeps AveragePool's divisor equal to kernel tap count and avoids padding
+// masks. Cases involving padding, auto_pad, partial ceil/output windows, or
+// dynamic shapes are left native until the pass grows explicit mask/divisor
+// support.
+constexpr const char* kMainOnnxDomain = "";
+constexpr const char* kAiOnnxDomain = "ai.onnx";
+
+// Guardrail for graph growth. Dilated pooling lowers to one Slice per kernel
+// tap, so very large kernels should not explode the proto in a compatibility
+// pass. The WebNN conformance cases that motivated this are 3x3.
+constexpr size_t kMaxLoweredTaps = 256;
+
+struct TensorMetadata
+{
+    std::optional<int32_t> element_type;
+    std::vector<int64_t> shape;
+};
+
+struct GraphIndex
+{
+    explicit GraphIndex(const onnx::GraphProto& graph)
+    {
+        for (const auto& initializer : graph.initializer())
+        {
+            auto& metadata = tensor_metadata[initializer.name()];
+            metadata.element_type = initializer.data_type();
+            metadata.shape.assign(initializer.dims().begin(), initializer.dims().end());
+        }
+
+        for (const auto& value_info : graph.input())
+        {
+            AddValueInfo(value_info);
+        }
+        for (const auto& value_info : graph.value_info())
+        {
+            AddValueInfo(value_info);
+        }
+        for (const auto& value_info : graph.output())
+        {
+            AddValueInfo(value_info);
+        }
+    }
+
+    std::optional<int32_t> FindTensorElementType(const std::string& name) const
+    {
+        const auto it = tensor_metadata.find(name);
+        return it == tensor_metadata.end() ? std::nullopt : it->second.element_type;
+    }
+
+    bool TryGetStaticShape(const std::string& name, std::vector<int64_t>& shape) const
+    {
+        shape.clear();
+        const auto it = tensor_metadata.find(name);
+        if (it == tensor_metadata.end() || it->second.shape.empty())
+        {
+            return false;
+        }
+
+        for (const auto dim : it->second.shape)
+        {
+            if (dim <= 0)
+            {
+                shape.clear();
+                return false;
+            }
+        }
+
+        shape = it->second.shape;
+        return true;
+    }
+
+    std::unordered_map<std::string, TensorMetadata> tensor_metadata;
+
+private:
+    void AddValueInfo(const onnx::ValueInfoProto& value_info)
+    {
+        if (value_info.name().empty() || !value_info.has_type() || !value_info.type().has_tensor_type())
+        {
+            return;
+        }
+
+        const auto& tensor_type = value_info.type().tensor_type();
+        auto& metadata = tensor_metadata[value_info.name()];
+        metadata.element_type = tensor_type.elem_type();
+        metadata.shape.clear();
+        if (!tensor_type.has_shape())
+        {
+            return;
+        }
+
+        metadata.shape.reserve(static_cast<size_t>(tensor_type.shape().dim_size()));
+        for (const auto& dim : tensor_type.shape().dim())
+        {
+            metadata.shape.push_back(dim.has_dim_value() ? dim.dim_value() : -1);
+        }
+    }
+};
+
+std::optional<int64_t> FindIntAttribute(const onnx::NodeProto& node, const std::string& name)
+{
+    for (const auto& attr : node.attribute())
+    {
+        if (attr.name() == name && attr.type() == onnx::AttributeProto_AttributeType_INT)
+        {
+            return attr.i();
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> FindStringAttribute(const onnx::NodeProto& node, const std::string& name)
+{
+    for (const auto& attr : node.attribute())
+    {
+        if (attr.name() == name && attr.type() == onnx::AttributeProto_AttributeType_STRING)
+        {
+            return attr.s();
+        }
+    }
+    return std::nullopt;
+}
+
+bool TryFindIntVectorAttribute(const onnx::NodeProto& node, const std::string& name, std::vector<int64_t>& values)
+{
+    for (const auto& attr : node.attribute())
+    {
+        if (attr.name() == name && attr.type() == onnx::AttributeProto_AttributeType_INTS)
+        {
+            values.assign(attr.ints().begin(), attr.ints().end());
+            return true;
+        }
+    }
+    values.clear();
+    return false;
+}
+
+bool HasMainOnnxDomain(const onnx::NodeProto& node)
+{
+    return node.domain().empty() || node.domain() == kMainOnnxDomain || node.domain() == kAiOnnxDomain;
+}
+
+bool IsSupportedPoolOp(const onnx::NodeProto& node)
+{
+    return HasMainOnnxDomain(node) && (node.op_type() == "AveragePool" || node.op_type() == "MaxPool");
+}
+
+bool IsSupportedElementType(int32_t element_type)
+{
+    return element_type == onnx::TensorProto_DataType_FLOAT ||
+           element_type == onnx::TensorProto_DataType_FLOAT16;
+}
+
+std::vector<int64_t> DefaultVector(size_t size, int64_t value)
+{
+    return std::vector<int64_t>(size, value);
+}
+
+bool HasNonZeroPadding(const std::vector<int64_t>& pads)
+{
+    return std::any_of(pads.begin(), pads.end(), [](int64_t value) { return value != 0; });
+}
+
+bool HasNonUnitDilation(const std::vector<int64_t>& dilations)
+{
+    return std::any_of(dilations.begin(), dilations.end(), [](int64_t value) { return value != 1; });
+}
+
+bool AllPositive(const std::vector<int64_t>& values)
+{
+    return std::all_of(values.begin(), values.end(), [](int64_t value) { return value > 0; });
+}
+
+bool CheckedMultiply(size_t lhs, int64_t rhs, size_t& result)
+{
+    if (rhs <= 0)
+    {
+        return false;
+    }
+
+    const auto rhs_size = static_cast<size_t>(rhs);
+    if (lhs > std::numeric_limits<size_t>::max() / rhs_size)
+    {
+        return false;
+    }
+
+    result = lhs * rhs_size;
+    return true;
+}
+
+std::string MakeLoweredName(const std::string& base, const char* suffix, size_t unique_id)
+{
+    std::ostringstream oss;
+    oss << "__trt_rtx_pool_dilation_lowered_" << unique_id << "_" << base << "_" << suffix;
+    return oss.str();
+}
+
+void AddInt64VectorInitializer(onnx::GraphProto& graph, const std::string& name, const std::vector<int64_t>& values)
+{
+    auto* tensor_proto = graph.add_initializer();
+    tensor_proto->set_name(name);
+    tensor_proto->set_data_type(onnx::TensorProto_DataType_INT64);
+    tensor_proto->set_data_location(onnx::TensorProto_DataLocation_DEFAULT);
+    tensor_proto->add_dims(static_cast<int64_t>(values.size()));
+    tensor_proto->set_raw_data(values.data(), values.size() * sizeof(int64_t));
+}
+
+uint16_t Float32ToFloat16Bits(float value)
+{
+    uint32_t bits = 0;
+    std::memcpy(&bits, &value, sizeof(bits));
+
+    const uint32_t sign = (bits >> 16) & 0x8000;
+    int32_t exponent = static_cast<int32_t>((bits >> 23) & 0xff) - 127 + 15;
+    uint32_t mantissa = bits & 0x7fffff;
+
+    if (exponent <= 0)
+    {
+        if (exponent < -10)
+        {
+            return static_cast<uint16_t>(sign);
+        }
+
+        mantissa |= 0x800000;
+        const uint32_t shifted = mantissa >> static_cast<uint32_t>(1 - exponent);
+        return static_cast<uint16_t>(sign | ((shifted + 0x1000) >> 13));
+    }
+
+    if (exponent >= 31)
+    {
+        return static_cast<uint16_t>(sign | 0x7c00);
+    }
+
+    return static_cast<uint16_t>(sign | (static_cast<uint32_t>(exponent) << 10) | ((mantissa + 0x1000) >> 13));
+}
+
+void AddFloatScalarInitializer(onnx::GraphProto& graph, const std::string& name, int32_t element_type, float value)
+{
+    auto* tensor_proto = graph.add_initializer();
+    tensor_proto->set_name(name);
+    tensor_proto->set_data_type(element_type);
+    tensor_proto->set_data_location(onnx::TensorProto_DataLocation_DEFAULT);
+
+    if (element_type == onnx::TensorProto_DataType_FLOAT16)
+    {
+        const uint16_t half_bits = Float32ToFloat16Bits(value);
+        tensor_proto->set_raw_data(&half_bits, sizeof(half_bits));
+    }
+    else
+    {
+        tensor_proto->set_raw_data(&value, sizeof(value));
+    }
+}
+
+onnx::NodeProto* AppendNode(google::protobuf::RepeatedPtrField<onnx::NodeProto>& nodes,
+                            const onnx::NodeProto& source_node, const std::string& op_type, const std::string& name,
+                            const std::vector<std::string>& inputs, const std::vector<std::string>& outputs)
+{
+    auto* new_node = nodes.Add();
+    new_node->set_name(name);
+    new_node->set_domain(kMainOnnxDomain);
+    new_node->set_op_type(op_type);
+    // Preserve the original ORT node id doc_string so capability bookkeeping
+    // can still attribute the lowered helper nodes to the source pooling node.
+    new_node->set_doc_string(source_node.doc_string());
+    for (const auto& input : inputs)
+    {
+        new_node->add_input(input);
+    }
+    for (const auto& output : outputs)
+    {
+        new_node->add_output(output);
+    }
+    return new_node;
+}
+
+struct PoolLoweringPlan
+{
+    bool is_average_pool = false;
+    int32_t element_type = 0;
+    std::vector<int64_t> input_shape;
+    std::vector<int64_t> output_shape;
+    std::vector<int64_t> kernel_shape;
+    std::vector<int64_t> strides;
+    std::vector<int64_t> dilations;
+    size_t tap_count = 0;
+};
+
+bool TryBuildPoolLoweringPlan(const onnx::NodeProto& node, const GraphIndex& index, PoolLoweringPlan& plan)
+{
+    plan = {};
+    if (!IsSupportedPoolOp(node) || node.input_size() != 1 || node.input(0).empty() || node.output_size() != 1 ||
+        node.output(0).empty())
+    {
+        return false;
+    }
+
+    const auto auto_pad = FindStringAttribute(node, "auto_pad");
+    if (auto_pad.has_value() && *auto_pad != "NOTSET")
+    {
+        // SAME_* auto padding changes edge-window membership. Leave it native
+        // until the lowering grows explicit padding/mask support.
+        return false;
+    }
+
+    if (!TryFindIntVectorAttribute(node, "kernel_shape", plan.kernel_shape) || plan.kernel_shape.empty() ||
+        !AllPositive(plan.kernel_shape))
+    {
+        // ONNX pooling stores the spatial window in kernel_shape. We need it
+        // to enumerate the tap coordinates that will become Slice nodes.
+        return false;
+    }
+
+    const size_t spatial_rank = plan.kernel_shape.size();
+    if (spatial_rank > static_cast<size_t>(std::numeric_limits<int64_t>::max() - 2))
+    {
+        return false;
+    }
+
+    if (!TryFindIntVectorAttribute(node, "strides", plan.strides))
+    {
+        plan.strides = DefaultVector(spatial_rank, 1);
+    }
+    if (!TryFindIntVectorAttribute(node, "dilations", plan.dilations))
+    {
+        plan.dilations = DefaultVector(spatial_rank, 1);
+    }
+
+    std::vector<int64_t> pads;
+    if (!TryFindIntVectorAttribute(node, "pads", pads))
+    {
+        pads = DefaultVector(spatial_rank * 2, 0);
+    }
+
+    if (plan.strides.size() != spatial_rank || plan.dilations.size() != spatial_rank ||
+        pads.size() != spatial_rank * 2 || !AllPositive(plan.strides) || !AllPositive(plan.dilations) ||
+        !HasNonUnitDilation(plan.dilations) || HasNonZeroPadding(pads))
+    {
+        // Policy: support only the equivalence we can prove cheaply:
+        // no explicit padding and at least one non-unit dilation. Padding
+        // would require per-output validity masks and, for AveragePool,
+        // count_include_pad-aware divisors.
+        return false;
+    }
+
+    if (!index.TryGetStaticShape(node.input(0), plan.input_shape) ||
+        plan.input_shape.size() != spatial_rank + 2 ||
+        !index.TryGetStaticShape(node.output(0), plan.output_shape) ||
+        plan.output_shape.size() != plan.input_shape.size())
+    {
+        // Static input/output shapes are required because Slice starts/ends are
+        // emitted as initializers. Dynamic-shape lowering would need Shape,
+        // Gather, arithmetic, and runtime-computed Slice parameters.
+        return false;
+    }
+
+    if (plan.output_shape[0] != plan.input_shape[0] || plan.output_shape[1] != plan.input_shape[1])
+    {
+        // ONNX AveragePool/MaxPool preserve N and C. If metadata disagrees,
+        // do not manufacture helper nodes around an inconsistent graph.
+        return false;
+    }
+
+    const auto element_type = index.FindTensorElementType(node.input(0));
+    if (!element_type.has_value() || !IsSupportedElementType(*element_type))
+    {
+        // WebNN exposes these failing cases as fp32/fp16. Keeping the pass to
+        // floating types avoids integer average/division surprises and keeps
+        // the scalar divisor representable in the same tensor type.
+        return false;
+    }
+
+    plan.is_average_pool = node.op_type() == "AveragePool";
+    plan.element_type = *element_type;
+    plan.tap_count = 1;
+    for (const auto kernel_dim : plan.kernel_shape)
+    {
+        if (!CheckedMultiply(plan.tap_count, kernel_dim, plan.tap_count) || plan.tap_count > kMaxLoweredTaps)
+        {
+            return false;
+        }
+    }
+
+    for (size_t dim = 0; dim < spatial_rank; ++dim)
+    {
+        const auto output_dim = plan.output_shape[dim + 2];
+        if (output_dim <= 0)
+        {
+            return false;
+        }
+
+        const auto last_input_index =
+            (output_dim - 1) * plan.strides[dim] + (plan.kernel_shape[dim] - 1) * plan.dilations[dim];
+        if (last_input_index >= plan.input_shape[dim + 2])
+        {
+            // Every lowered Slice tap must read real input elements for every
+            // output coordinate. If ceil_mode/output sizing creates a partial
+            // final window, native pooling semantics require masking instead.
+            return false;
+        }
+    }
+
+    return true;
+}
+
+std::vector<int64_t> DecodeTapCoordinates(size_t tap_index, const std::vector<int64_t>& kernel_shape)
+{
+    std::vector<int64_t> coordinates(kernel_shape.size(), 0);
+    for (size_t dim = kernel_shape.size(); dim > 0; --dim)
+    {
+        const auto kernel_dim = static_cast<size_t>(kernel_shape[dim - 1]);
+        coordinates[dim - 1] = static_cast<int64_t>(tap_index % kernel_dim);
+        tap_index /= kernel_dim;
+    }
+    return coordinates;
+}
+
+void BuildSliceParameters(const PoolLoweringPlan& plan, const std::vector<int64_t>& tap_coordinates,
+                          std::vector<int64_t>& starts, std::vector<int64_t>& ends, std::vector<int64_t>& axes,
+                          std::vector<int64_t>& steps)
+{
+    const size_t rank = plan.input_shape.size();
+    starts.assign(rank, 0);
+    ends = plan.input_shape;
+    axes.resize(rank);
+    steps.assign(rank, 1);
+
+    for (size_t dim = 0; dim < rank; ++dim)
+    {
+        axes[dim] = static_cast<int64_t>(dim);
+    }
+
+    for (size_t dim = 0; dim < plan.kernel_shape.size(); ++dim)
+    {
+        const size_t tensor_dim = dim + 2;
+
+        // For output coordinate o and kernel coordinate k, dilated pooling
+        // reads input index:
+        //   input = o * stride + k * dilation
+        // A Slice with:
+        //   start = k * dilation
+        //   step  = stride
+        //   end   = start + (output_size - 1) * stride + 1
+        // therefore gathers exactly this tap for every output coordinate.
+        starts[tensor_dim] = tap_coordinates[dim] * plan.dilations[dim];
+        ends[tensor_dim] = starts[tensor_dim] + (plan.output_shape[tensor_dim] - 1) * plan.strides[dim] + 1;
+        steps[tensor_dim] = plan.strides[dim];
+    }
+}
+
+bool TryLowerPoolNode(onnx::GraphProto& graph, const onnx::NodeProto& node,
+                      google::protobuf::RepeatedPtrField<onnx::NodeProto>& lowered_nodes, const GraphIndex& index,
+                      size_t& unique_id)
+{
+    PoolLoweringPlan plan;
+    if (!TryBuildPoolLoweringPlan(node, index, plan))
+    {
+        return false;
+    }
+
+    std::vector<std::string> tap_outputs;
+    tap_outputs.reserve(plan.tap_count);
+
+    for (size_t tap_index = 0; tap_index < plan.tap_count; ++tap_index)
+    {
+        const bool single_tap = plan.tap_count == 1;
+        const auto tap_coordinates = DecodeTapCoordinates(tap_index, plan.kernel_shape);
+
+        std::vector<int64_t> starts;
+        std::vector<int64_t> ends;
+        std::vector<int64_t> axes;
+        std::vector<int64_t> steps;
+        BuildSliceParameters(plan, tap_coordinates, starts, ends, axes, steps);
+
+        const auto base_name = MakeLoweredName(node.output(0), "tap", ++unique_id);
+        const auto starts_name = base_name + "_starts";
+        const auto ends_name = base_name + "_ends";
+        const auto axes_name = base_name + "_axes";
+        const auto steps_name = base_name + "_steps";
+        const auto output_name = single_tap ? node.output(0) : base_name + "_output";
+
+        AddInt64VectorInitializer(graph, starts_name, starts);
+        AddInt64VectorInitializer(graph, ends_name, ends);
+        AddInt64VectorInitializer(graph, axes_name, axes);
+        AddInt64VectorInitializer(graph, steps_name, steps);
+
+        AppendNode(lowered_nodes, node, "Slice", base_name + "_slice",
+                   {node.input(0), starts_name, ends_name, axes_name, steps_name}, {output_name});
+
+        if (!single_tap)
+        {
+            tap_outputs.push_back(output_name);
+        }
+    }
+
+    if (plan.tap_count == 1)
+    {
+        return true;
+    }
+
+    if (plan.is_average_pool)
+    {
+        // With zero padding and fully-valid windows, AveragePool's divisor is
+        // the kernel tap count. That lets a chain of Add nodes plus one scalar
+        // Div reproduce the native operator exactly for fp32/fp16.
+        std::string sum_output = tap_outputs[0];
+        for (size_t i = 1; i < tap_outputs.size(); ++i)
+        {
+            const auto add_output = MakeLoweredName(node.output(0), "sum", ++unique_id);
+            AppendNode(lowered_nodes, node, "Add", add_output + "_add", {sum_output, tap_outputs[i]}, {add_output});
+            sum_output = add_output;
+        }
+
+        const auto divisor_name = MakeLoweredName(node.output(0), "divisor", ++unique_id);
+        AddFloatScalarInitializer(graph, divisor_name, plan.element_type, static_cast<float>(plan.tap_count));
+        AppendNode(lowered_nodes, node, "Div", MakeLoweredName(node.output(0), "average", ++unique_id),
+                   {sum_output, divisor_name}, {node.output(0)});
+    }
+    else
+    {
+        // MaxPool over a dilated window is just the elementwise maximum across
+        // the same tap tensors. ONNX Max accepts variadic inputs, but a binary
+        // chain keeps the lowered graph simple for parser compatibility.
+        std::string max_output = tap_outputs[0];
+        for (size_t i = 1; i < tap_outputs.size(); ++i)
+        {
+            const bool is_last = i == tap_outputs.size() - 1;
+            const auto next_output = is_last ? node.output(0) : MakeLoweredName(node.output(0), "max", ++unique_id);
+            AppendNode(lowered_nodes, node, "Max", next_output + "_max", {max_output, tap_outputs[i]}, {next_output});
+            max_output = next_output;
+        }
+    }
+
+    return true;
+}
+
+void RewritePoolingDilations(onnx::GraphProto& graph)
+{
+    const GraphIndex index(graph);
+    google::protobuf::RepeatedPtrField<onnx::NodeProto> lowered_nodes;
+    size_t unique_id = 0;
+
+    for (const auto& node : graph.node())
+    {
+        if (TryLowerPoolNode(graph, node, lowered_nodes, index, unique_id))
+        {
+            continue;
+        }
+
+        *lowered_nodes.Add() = node;
+    }
+
+    graph.mutable_node()->Swap(&lowered_nodes);
+}
+
+}  // namespace
+
+void RunPoolingDilationCompatibilityForTensorRt(onnx::ModelProto& model_proto)
+{
+    RewritePoolingDilations(*model_proto.mutable_graph());
+}
+
+}  // namespace trt_rtx_ep

--- a/src/pooling_dilation_compatibility.h
+++ b/src/pooling_dilation_compatibility.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "onnx/onnx_pb.h"
+
+namespace trt_rtx_ep
+{
+
+// Rewrites ONNX AveragePool/MaxPool nodes with non-unit dilations into
+// parser-friendly primitive ONNX nodes before TRT-RTX sees the proto.
+//
+// TensorRT-RTX currently rejects pooling dilations other than 1. For cases
+// where every dilated pooling window maps to real input elements, a dilated
+// pool is exactly equivalent to:
+//   * Slice each tapped kernel position across all output locations.
+//   * AveragePool: Add all tap tensors and divide by tap count.
+//   * MaxPool: take elementwise Max across all tap tensors.
+//
+// The pass intentionally lowers only the subset it can prove equivalent:
+// static-shape pooling, zero explicit padding, one output, and no partial
+// windows. Padding/ceil partial-window cases need additional masking/divisor
+// logic and are left native rather than approximated.
+void RunPoolingDilationCompatibilityForTensorRt(onnx::ModelProto& model_proto);
+
+}  // namespace trt_rtx_ep

--- a/src/proto_node_id_utils.h
+++ b/src/proto_node_id_utils.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace trt_rtx_ep
+{
+
+// Decodes the original ORT node id that OrtGraphToProto stores in
+// NodeProto::doc_string. Returns nullopt for synthesized helper nodes or any
+// foreign / legacy doc_string content that does not parse as a numeric ORT id.
+inline std::optional<size_t> TryParseNodeId(const std::string& doc_string)
+{
+    if (doc_string.empty())
+    {
+        return std::nullopt;
+    }
+
+    try
+    {
+        return static_cast<size_t>(std::stoull(doc_string));
+    }
+    catch (...)
+    {
+        return std::nullopt;
+    }
+}
+
+}  // namespace trt_rtx_ep

--- a/src/qdq_lowering.cc
+++ b/src/qdq_lowering.cc
@@ -1,0 +1,2241 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Q/DQ lowering pass for the TensorRT-RTX EP.
+//
+// Design summary (see also qdq_lowering.h):
+//
+//   * The policy layer (Evaluate*Lowering, ShouldLowerQuantizeLinear,
+//     BaseMustLower*, IsSymmetricConstantDequantizeCandidate, ...) decides
+//     *whether* a Q/DQ node must be rewritten. It is intentionally separated
+//     from the rewrite layer so rule changes never touch the arithmetic.
+//
+//   * The rewrite layer (driver loop in RunQdqLoweringForTensorRt +
+//     TryFoldConstantDequantizeLinear + Append* helpers) materializes the
+//     ONNX math for DQ / Q in terms of Cast / Sub / Mul / Div / Add / Round
+//     / Min / Max / Cast, with a few numerical refinements (integer-first
+//     subtraction for int32/uint32, fp32 promotion for int16/uint16 with
+//     fp16/bf16 scales, zero_point dtype promotion for safe subtraction).
+//
+//   * Every emitted helper node inherits the *original* ORT node id via
+//     NodeProto::doc_string so the provider's proto->ORT remap can still
+//     credit ownership to the correct ORT node (see provider comments near
+//     build_proto_to_ort_index).
+//
+//   * Graph ownership invariant: every Q/DQ node in the input proto ends up
+//     represented in the output proto either verbatim (kept native) or as a
+//     set of lowered nodes sharing its doc_string (and, for folded constant
+//     DQ, an entry in LoweredQdqInfo::folded_constant_nodes). The driver
+//     *never* drops a node on the floor.
+
+#include "qdq_lowering.h"
+#include "proto_node_id_utils.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace trt_rtx_ep
+{
+namespace
+{
+// Sentinel location string used by the provider's OrtGraphToProto handler.
+// When a TensorProto carries this location, `offset` is NOT a file offset;
+// it is a raw pointer to ORT-owned initializer bytes, reinterpret_cast to
+// int64_t. TryGetTensorDataView knows how to decode that convention.
+// MUST match the constant in tensorrt_rtx_execution_provider.cc.
+constexpr const char* kExternalMemAddrLocation = "_MEM_ADDR_";
+constexpr const char* kMainOnnxDomain = "";
+
+struct TensorDataView
+{
+    const void* data = nullptr;
+    size_t bytes = 0;
+    std::vector<uint8_t> owned_bytes;
+};
+
+struct TensorMetadata
+{
+    std::optional<int32_t> element_type;
+    std::vector<int64_t> shape;
+    bool is_graph_input = false;
+};
+
+struct GraphIndex
+{
+    explicit GraphIndex(onnx::GraphProto& graph_proto)
+        : graph(graph_proto)
+    {
+        Build();
+    }
+
+    void RebuildTensorMetadata(const std::string& name)
+    {
+        tensor_metadata.erase(name);
+        AddValueInfo(name, nullptr, true);
+        for (const auto& value_info : graph.input())
+        {
+            if (value_info.name() == name)
+            {
+                AddValueInfo(name, &value_info, true);
+            }
+        }
+        for (const auto& value_info : graph.value_info())
+        {
+            if (value_info.name() == name)
+            {
+                AddValueInfo(name, &value_info, false);
+            }
+        }
+        for (const auto& value_info : graph.output())
+        {
+            if (value_info.name() == name)
+            {
+                AddValueInfo(name, &value_info, false);
+            }
+        }
+        if (const auto* initializer = FindInitializer(name))
+        {
+            auto& metadata = tensor_metadata[name];
+            metadata.element_type = initializer->data_type();
+            metadata.shape.assign(initializer->dims().begin(), initializer->dims().end());
+        }
+    }
+
+    const onnx::TensorProto* FindInitializer(const std::string& name) const
+    {
+        auto it = initializer_map.find(name);
+        return it == initializer_map.end() ? nullptr : it->second;
+    }
+
+    std::optional<int32_t> FindTensorElementType(const std::string& name) const
+    {
+        auto it = tensor_metadata.find(name);
+        if (it == tensor_metadata.end())
+        {
+            return std::nullopt;
+        }
+        return it->second.element_type;
+    }
+
+    bool IsGraphInput(const std::string& name) const
+    {
+        auto it = tensor_metadata.find(name);
+        return it != tensor_metadata.end() && it->second.is_graph_input;
+    }
+
+    std::optional<int64_t> FindTensorRank(const std::string& name) const
+    {
+        auto it = tensor_metadata.find(name);
+        if (it == tensor_metadata.end() || it->second.shape.empty())
+        {
+            return std::nullopt;
+        }
+        return static_cast<int64_t>(it->second.shape.size());
+    }
+
+    bool TryGetTensorShape(const std::string& name, std::vector<int64_t>& shape) const
+    {
+        shape.clear();
+        auto it = tensor_metadata.find(name);
+        if (it == tensor_metadata.end())
+        {
+            return false;
+        }
+
+        if (it->second.shape.empty())
+        {
+            return true;
+        }
+
+        for (const auto dim : it->second.shape)
+        {
+            if (dim <= 0)
+            {
+                shape.clear();
+                return false;
+            }
+        }
+
+        shape = it->second.shape;
+        return true;
+    }
+
+    void NoteInitializer(const onnx::TensorProto& initializer)
+    {
+        initializer_map[initializer.name()] = &initializer;
+        auto& metadata = tensor_metadata[initializer.name()];
+        metadata.element_type = initializer.data_type();
+        metadata.shape.assign(initializer.dims().begin(), initializer.dims().end());
+    }
+
+    const onnx::NodeProto* GetNode(size_t index) const
+    {
+        if (index >= static_cast<size_t>(graph.node_size()))
+        {
+            return nullptr;
+        }
+        return &graph.node(static_cast<int>(index));
+    }
+
+    const onnx::NodeProto* FindProducer(const std::string& name) const
+    {
+        auto it = producer_node_indices.find(name);
+        return it == producer_node_indices.end() ? nullptr : GetNode(it->second);
+    }
+
+    const std::vector<size_t>* FindConsumerNodeIndices(const std::string& name) const
+    {
+        auto it = consumer_node_indices.find(name);
+        return it == consumer_node_indices.end() ? nullptr : &it->second;
+    }
+
+    onnx::GraphProto& graph;
+    std::unordered_map<std::string, const onnx::TensorProto*> initializer_map;
+    std::unordered_map<std::string, TensorMetadata> tensor_metadata;
+    std::unordered_map<std::string, size_t> producer_node_indices;
+    std::unordered_map<std::string, std::vector<size_t>> consumer_node_indices;
+
+private:
+    void Build()
+    {
+        initializer_map.clear();
+        tensor_metadata.clear();
+        producer_node_indices.clear();
+        consumer_node_indices.clear();
+        for (const auto& initializer : graph.initializer())
+        {
+            initializer_map[initializer.name()] = &initializer;
+            auto& metadata = tensor_metadata[initializer.name()];
+            metadata.element_type = initializer.data_type();
+            metadata.shape.assign(initializer.dims().begin(), initializer.dims().end());
+        }
+        for (const auto& value_info : graph.input())
+        {
+            AddValueInfo(value_info.name(), &value_info, true);
+        }
+        for (const auto& value_info : graph.value_info())
+        {
+            AddValueInfo(value_info.name(), &value_info, false);
+        }
+        for (const auto& value_info : graph.output())
+        {
+            AddValueInfo(value_info.name(), &value_info, false);
+        }
+        for (int node_index = 0; node_index < graph.node_size(); ++node_index)
+        {
+            const auto& node = graph.node(node_index);
+            for (const auto& input_name : node.input())
+            {
+                if (!input_name.empty())
+                {
+                    consumer_node_indices[input_name].push_back(static_cast<size_t>(node_index));
+                }
+            }
+            for (const auto& output_name : node.output())
+            {
+                if (!output_name.empty())
+                {
+                    producer_node_indices[output_name] = static_cast<size_t>(node_index);
+                }
+            }
+        }
+    }
+
+    void AddValueInfo(const std::string& name, const onnx::ValueInfoProto* value_info, bool is_input)
+    {
+        auto& metadata = tensor_metadata[name];
+        metadata.is_graph_input = metadata.is_graph_input || is_input;
+        if (value_info == nullptr || !value_info->has_type() || !value_info->type().has_tensor_type())
+        {
+            return;
+        }
+
+        const auto& tensor_type = value_info->type().tensor_type();
+        metadata.element_type = tensor_type.elem_type();
+        metadata.shape.clear();
+        if (!tensor_type.has_shape())
+        {
+            return;
+        }
+        metadata.shape.reserve(static_cast<size_t>(tensor_type.shape().dim_size()));
+        for (const auto& dim : tensor_type.shape().dim())
+        {
+            metadata.shape.push_back(dim.has_dim_value() ? dim.dim_value() : -1);
+        }
+    }
+};
+
+bool TryReadIntegerTensorData(const onnx::TensorProto& tensor, std::vector<int64_t>& values);
+bool TryReadFloatingTensorData(const onnx::TensorProto& tensor, std::vector<double>& values);
+
+size_t GetTensorElementCount(const onnx::TensorProto& tensor)
+{
+    if (tensor.dims_size() == 0)
+    {
+        return 1;
+    }
+
+    size_t count = 1;
+    for (const auto dim : tensor.dims())
+    {
+        if (dim <= 0)
+        {
+            return 0;
+        }
+        count *= static_cast<size_t>(dim);
+    }
+    return count;
+}
+
+size_t GetTensorElementSize(int32_t data_type)
+{
+    switch (data_type)
+    {
+        case onnx::TensorProto_DataType_FLOAT:
+        case onnx::TensorProto_DataType_INT32:
+        case onnx::TensorProto_DataType_UINT32:
+            return 4;
+        case onnx::TensorProto_DataType_DOUBLE:
+        case onnx::TensorProto_DataType_INT64:
+        case onnx::TensorProto_DataType_UINT64:
+            return 8;
+        case onnx::TensorProto_DataType_FLOAT16:
+        case onnx::TensorProto_DataType_BFLOAT16:
+        case onnx::TensorProto_DataType_INT16:
+        case onnx::TensorProto_DataType_UINT16:
+            return 2;
+        case onnx::TensorProto_DataType_INT8:
+        case onnx::TensorProto_DataType_UINT8:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+float Float16BitsToFloat(uint16_t bits)
+{
+    const uint32_t sign = static_cast<uint32_t>(bits & 0x8000) << 16;
+    const uint32_t exponent = (bits >> 10) & 0x1f;
+    const uint32_t mantissa = bits & 0x03ff;
+
+    uint32_t result_bits = 0;
+    if (exponent == 0)
+    {
+        if (mantissa == 0)
+        {
+            result_bits = sign;
+        }
+        else
+        {
+            uint32_t normalized_mantissa = mantissa;
+            uint32_t normalized_exponent = 0;
+            while ((normalized_mantissa & 0x0400) == 0)
+            {
+                normalized_mantissa <<= 1;
+                ++normalized_exponent;
+            }
+            normalized_mantissa &= 0x03ff;
+            result_bits = sign | ((127 - 15 - normalized_exponent) << 23) | (normalized_mantissa << 13);
+        }
+    }
+    else if (exponent == 0x1f)
+    {
+        result_bits = sign | 0x7f800000 | (mantissa << 13);
+    }
+    else
+    {
+        result_bits = sign | ((exponent + (127 - 15)) << 23) | (mantissa << 13);
+    }
+
+    float value = 0.0f;
+    std::memcpy(&value, &result_bits, sizeof(value));
+    return value;
+}
+
+float BFloat16BitsToFloat(uint16_t bits)
+{
+    const uint32_t raw = static_cast<uint32_t>(bits) << 16;
+    float value = 0.0f;
+    std::memcpy(&value, &raw, sizeof(value));
+    return value;
+}
+
+template <typename T>
+bool CopyTypedValues(const void* source, size_t source_count, std::vector<uint8_t>& dest)
+{
+    if (source_count == 0)
+    {
+        dest.clear();
+        return true;
+    }
+    dest.resize(source_count * sizeof(T));
+    std::memcpy(dest.data(), source, dest.size());
+    return true;
+}
+
+bool PackTensorFromTypedFields(const onnx::TensorProto& tensor, TensorDataView& data_view)
+{
+    const size_t element_count = GetTensorElementCount(tensor);
+    if (element_count == 0)
+    {
+        return false;
+    }
+
+    switch (tensor.data_type())
+    {
+        case onnx::TensorProto_DataType_FLOAT:
+            if (static_cast<size_t>(tensor.float_data_size()) == element_count)
+            {
+                return CopyTypedValues<float>(tensor.float_data().data(), element_count, data_view.owned_bytes);
+            }
+            break;
+        case onnx::TensorProto_DataType_DOUBLE:
+            if (static_cast<size_t>(tensor.double_data_size()) == element_count)
+            {
+                return CopyTypedValues<double>(tensor.double_data().data(), element_count, data_view.owned_bytes);
+            }
+            break;
+        case onnx::TensorProto_DataType_INT64:
+            if (static_cast<size_t>(tensor.int64_data_size()) == element_count)
+            {
+                return CopyTypedValues<int64_t>(tensor.int64_data().data(), element_count, data_view.owned_bytes);
+            }
+            break;
+        case onnx::TensorProto_DataType_UINT64:
+            if (static_cast<size_t>(tensor.uint64_data_size()) == element_count)
+            {
+                return CopyTypedValues<uint64_t>(tensor.uint64_data().data(), element_count, data_view.owned_bytes);
+            }
+            break;
+        case onnx::TensorProto_DataType_FLOAT16:
+        case onnx::TensorProto_DataType_BFLOAT16:
+        case onnx::TensorProto_DataType_INT8:
+        case onnx::TensorProto_DataType_UINT8:
+        case onnx::TensorProto_DataType_INT16:
+        case onnx::TensorProto_DataType_UINT16:
+        case onnx::TensorProto_DataType_INT32:
+        {
+            if (static_cast<size_t>(tensor.int32_data_size()) != element_count)
+            {
+                break;
+            }
+            data_view.owned_bytes.resize(element_count * GetTensorElementSize(tensor.data_type()));
+            for (size_t i = 0; i < element_count; ++i)
+            {
+                const int32_t value = tensor.int32_data(static_cast<int>(i));
+                switch (tensor.data_type())
+                {
+                    case onnx::TensorProto_DataType_FLOAT16:
+                    case onnx::TensorProto_DataType_BFLOAT16:
+                    {
+                        const uint16_t narrowed = static_cast<uint16_t>(value & 0xffff);
+                        std::memcpy(data_view.owned_bytes.data() + i * sizeof(uint16_t), &narrowed, sizeof(uint16_t));
+                        break;
+                    }
+                    case onnx::TensorProto_DataType_INT8:
+                    {
+                        const int8_t narrowed = static_cast<int8_t>(value);
+                        std::memcpy(data_view.owned_bytes.data() + i, &narrowed, sizeof(narrowed));
+                        break;
+                    }
+                    case onnx::TensorProto_DataType_UINT8:
+                    {
+                        const uint8_t narrowed = static_cast<uint8_t>(value);
+                        std::memcpy(data_view.owned_bytes.data() + i, &narrowed, sizeof(narrowed));
+                        break;
+                    }
+                    case onnx::TensorProto_DataType_INT16:
+                    {
+                        const int16_t narrowed = static_cast<int16_t>(value);
+                        std::memcpy(data_view.owned_bytes.data() + i * sizeof(int16_t), &narrowed, sizeof(narrowed));
+                        break;
+                    }
+                    case onnx::TensorProto_DataType_UINT16:
+                    {
+                        const uint16_t narrowed = static_cast<uint16_t>(value);
+                        std::memcpy(data_view.owned_bytes.data() + i * sizeof(uint16_t), &narrowed, sizeof(narrowed));
+                        break;
+                    }
+                    case onnx::TensorProto_DataType_INT32:
+                    {
+                        std::memcpy(data_view.owned_bytes.data() + i * sizeof(int32_t), &value, sizeof(value));
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            }
+            break;
+        }
+        case onnx::TensorProto_DataType_UINT32:
+            if (static_cast<size_t>(tensor.uint64_data_size()) == element_count)
+            {
+                data_view.owned_bytes.resize(element_count * sizeof(uint32_t));
+                for (size_t i = 0; i < element_count; ++i)
+                {
+                    const uint32_t value = static_cast<uint32_t>(tensor.uint64_data(static_cast<int>(i)));
+                    std::memcpy(data_view.owned_bytes.data() + i * sizeof(uint32_t), &value, sizeof(value));
+                }
+                break;
+            }
+            return false;
+        default:
+            return false;
+    }
+
+    if (data_view.owned_bytes.empty())
+    {
+        return false;
+    }
+
+    data_view.data = data_view.owned_bytes.data();
+    data_view.bytes = data_view.owned_bytes.size();
+    return true;
+}
+
+// Uniform accessor for initializer bytes regardless of how the serializer
+// emitted them. Three supported layouts, in priority order:
+//   1. Inline raw_data           - returned as a pointer to the proto's bytes.
+//   2. External with location
+//      == "_MEM_ADDR_"           - `offset` is a pointer into ORT-owned memory
+//                                   (see kExternalMemAddrLocation). We never
+//                                   copy; the view aliases ORT's buffer for
+//                                   the lifetime of this lowering pass.
+//   3. Typed fields (int32_data,
+//      float_data, ...)          - packed into owned_bytes so callers can
+//                                   treat all tensors uniformly.
+// Anything else (e.g. external on-disk) is intentionally unsupported here
+// because ORT never hands us those during EP lowering.
+bool TryGetTensorDataView(const onnx::TensorProto& tensor, TensorDataView& data_view)
+{
+    data_view = {};
+    if (tensor.has_raw_data())
+    {
+        data_view.data = tensor.raw_data().data();
+        data_view.bytes = static_cast<size_t>(tensor.raw_data().size());
+        return true;
+    }
+
+    if (tensor.data_location() == onnx::TensorProto_DataLocation_EXTERNAL)
+    {
+        std::string location;
+        std::string offset;
+        std::string length;
+        for (const auto& entry : tensor.external_data())
+        {
+            if (entry.key() == "location")
+            {
+                location = entry.value();
+            }
+            else if (entry.key() == "offset")
+            {
+                offset = entry.value();
+            }
+            else if (entry.key() == "length")
+            {
+                length = entry.value();
+            }
+        }
+
+        if (location == kExternalMemAddrLocation && !offset.empty())
+        {
+            const uintptr_t ptr_value = static_cast<uintptr_t>(std::stoull(offset));
+            data_view.data = reinterpret_cast<const void*>(ptr_value);
+            if (!length.empty())
+            {
+                data_view.bytes = static_cast<size_t>(std::stoull(length));
+            }
+            else
+            {
+                data_view.bytes = GetTensorElementCount(tensor) * GetTensorElementSize(tensor.data_type());
+            }
+            return data_view.data != nullptr && data_view.bytes > 0;
+        }
+    }
+
+    return PackTensorFromTypedFields(tensor, data_view);
+}
+
+template <typename T>
+bool TensorBytesHaveAnyNonZero(const TensorDataView& data_view, size_t element_count)
+{
+    if (data_view.bytes < element_count * sizeof(T))
+    {
+        return false;
+    }
+    const auto* values = static_cast<const T*>(data_view.data);
+    for (size_t i = 0; i < element_count; ++i)
+    {
+        if (values[i] != static_cast<T>(0))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool TensorHasAnyNonZeroValue(const onnx::TensorProto& tensor)
+{
+    TensorDataView data_view;
+    if (!TryGetTensorDataView(tensor, data_view))
+    {
+        return false;
+    }
+
+    const size_t element_count = GetTensorElementCount(tensor);
+    switch (tensor.data_type())
+    {
+        case onnx::TensorProto_DataType_INT8:
+            return TensorBytesHaveAnyNonZero<int8_t>(data_view, element_count);
+        case onnx::TensorProto_DataType_UINT8:
+            return TensorBytesHaveAnyNonZero<uint8_t>(data_view, element_count);
+        case onnx::TensorProto_DataType_INT16:
+            return TensorBytesHaveAnyNonZero<int16_t>(data_view, element_count);
+        case onnx::TensorProto_DataType_UINT16:
+        case onnx::TensorProto_DataType_FLOAT16:
+        case onnx::TensorProto_DataType_BFLOAT16:
+            return TensorBytesHaveAnyNonZero<uint16_t>(data_view, element_count);
+        case onnx::TensorProto_DataType_INT32:
+            return TensorBytesHaveAnyNonZero<int32_t>(data_view, element_count);
+        case onnx::TensorProto_DataType_UINT32:
+            return TensorBytesHaveAnyNonZero<uint32_t>(data_view, element_count);
+        case onnx::TensorProto_DataType_INT64:
+            return TensorBytesHaveAnyNonZero<int64_t>(data_view, element_count);
+        case onnx::TensorProto_DataType_UINT64:
+            return TensorBytesHaveAnyNonZero<uint64_t>(data_view, element_count);
+        case onnx::TensorProto_DataType_FLOAT:
+            return TensorBytesHaveAnyNonZero<float>(data_view, element_count);
+        case onnx::TensorProto_DataType_DOUBLE:
+            return TensorBytesHaveAnyNonZero<double>(data_view, element_count);
+        default:
+            return false;
+    }
+}
+
+// TRT-RTX native DequantizeLinear accepts low-bit integer inputs
+// (int8/uint8/int16/uint16). It rejects 32-bit integer DQ inputs, which ONNX
+// spec allows but TRT's Q/DQ path does not model. Those must be lowered.
+//
+// Policy knob: if TRT widens its DQ input support in a future release, revisit
+// this predicate together with GetDequantizeIntegerMathType.
+bool IsTensorRtUnsupportedQdqIntegerType(int32_t data_type)
+{
+    return data_type == onnx::TensorProto_DataType_INT32 || data_type == onnx::TensorProto_DataType_UINT32;
+}
+
+std::optional<int64_t> FindIntAttribute(const onnx::NodeProto& node, const std::string& name)
+{
+    for (const auto& attr : node.attribute())
+    {
+        if (attr.name() == name && attr.type() == onnx::AttributeProto_AttributeType_INT)
+        {
+            return attr.i();
+        }
+    }
+    return std::nullopt;
+}
+
+std::string MakeLoweredName(const std::string& base, const char* suffix, size_t unique_id)
+{
+    std::ostringstream oss;
+    oss << "__trt_rtx_qdq_lowered_" << unique_id << "_" << base << "_" << suffix;
+    return oss.str();
+}
+
+void SetScalarInitializerData(onnx::TensorProto& tensor_proto, int32_t data_type, int64_t int_value)
+{
+    tensor_proto.set_data_type(data_type);
+    tensor_proto.set_data_location(onnx::TensorProto_DataLocation_DEFAULT);
+    switch (data_type)
+    {
+        case onnx::TensorProto_DataType_INT8:
+        {
+            const int8_t value = static_cast<int8_t>(int_value);
+            tensor_proto.set_raw_data(&value, sizeof(value));
+            break;
+        }
+        case onnx::TensorProto_DataType_UINT8:
+        {
+            const uint8_t value = static_cast<uint8_t>(int_value);
+            tensor_proto.set_raw_data(&value, sizeof(value));
+            break;
+        }
+        case onnx::TensorProto_DataType_INT16:
+        {
+            const int16_t value = static_cast<int16_t>(int_value);
+            tensor_proto.set_raw_data(&value, sizeof(value));
+            break;
+        }
+        case onnx::TensorProto_DataType_UINT16:
+        {
+            const uint16_t value = static_cast<uint16_t>(int_value);
+            tensor_proto.set_raw_data(&value, sizeof(value));
+            break;
+        }
+        case onnx::TensorProto_DataType_INT32:
+        {
+            const int32_t value = static_cast<int32_t>(int_value);
+            tensor_proto.set_raw_data(&value, sizeof(value));
+            break;
+        }
+        case onnx::TensorProto_DataType_UINT32:
+        {
+            const uint32_t value = static_cast<uint32_t>(int_value);
+            tensor_proto.set_raw_data(&value, sizeof(value));
+            break;
+        }
+        case onnx::TensorProto_DataType_INT64:
+        {
+            const int64_t value = int_value;
+            tensor_proto.set_raw_data(&value, sizeof(value));
+            break;
+        }
+        case onnx::TensorProto_DataType_UINT64:
+        {
+            const uint64_t value = static_cast<uint64_t>(int_value);
+            tensor_proto.set_raw_data(&value, sizeof(value));
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+onnx::TensorProto* AddScalarInitializer(onnx::GraphProto& graph, GraphIndex& index, const std::string& name,
+                                        int32_t data_type, int64_t int_value)
+{
+    auto* tensor_proto = graph.add_initializer();
+    tensor_proto->set_name(name);
+    SetScalarInitializerData(*tensor_proto, data_type, int_value);
+    index.NoteInitializer(*tensor_proto);
+    return tensor_proto;
+}
+
+onnx::TensorProto* AddInt64VectorInitializer(onnx::GraphProto& graph, GraphIndex& index, const std::string& name,
+                                             const std::vector<int64_t>& values)
+{
+    auto* tensor_proto = graph.add_initializer();
+    tensor_proto->set_name(name);
+    tensor_proto->set_data_type(onnx::TensorProto_DataType_INT64);
+    tensor_proto->set_data_location(onnx::TensorProto_DataLocation_DEFAULT);
+    tensor_proto->add_dims(static_cast<int64_t>(values.size()));
+    tensor_proto->set_raw_data(values.data(), values.size() * sizeof(int64_t));
+    index.NoteInitializer(*tensor_proto);
+    return tensor_proto;
+}
+
+onnx::TensorProto* AddCopiedInitializerWithShape(onnx::GraphProto& graph, GraphIndex& index, const std::string& name,
+                                                 const onnx::TensorProto& source_tensor,
+                                                 const std::vector<int64_t>& new_shape)
+{
+    TensorDataView data_view;
+    if (!TryGetTensorDataView(source_tensor, data_view))
+    {
+        return nullptr;
+    }
+
+    const size_t element_size = GetTensorElementSize(source_tensor.data_type());
+    const size_t element_count = GetTensorElementCount(source_tensor);
+    if (element_size == 0 || data_view.bytes < element_size * element_count)
+    {
+        return nullptr;
+    }
+
+    auto* tensor_proto = graph.add_initializer();
+    tensor_proto->set_name(name);
+    tensor_proto->set_data_type(source_tensor.data_type());
+    tensor_proto->set_data_location(onnx::TensorProto_DataLocation_DEFAULT);
+    for (const auto dim : new_shape)
+    {
+        tensor_proto->add_dims(dim);
+    }
+    tensor_proto->set_raw_data(data_view.data, element_size * element_count);
+    index.NoteInitializer(*tensor_proto);
+    return tensor_proto;
+}
+
+onnx::TensorProto* AddPromotedIntegerInitializer(onnx::GraphProto& graph, GraphIndex& index, const std::string& name,
+                                                 const onnx::TensorProto& source_tensor, int32_t promoted_type)
+{
+    std::vector<int64_t> values;
+    if (!TryReadIntegerTensorData(source_tensor, values))
+    {
+        return nullptr;
+    }
+
+    auto* tensor_proto = graph.add_initializer();
+    tensor_proto->set_name(name);
+    tensor_proto->set_data_type(promoted_type);
+    tensor_proto->set_data_location(onnx::TensorProto_DataLocation_DEFAULT);
+    for (const auto dim : source_tensor.dims())
+    {
+        tensor_proto->add_dims(dim);
+    }
+
+    if (promoted_type == onnx::TensorProto_DataType_INT32)
+    {
+        std::vector<int32_t> promoted(values.size());
+        for (size_t i = 0; i < values.size(); ++i)
+        {
+            promoted[i] = static_cast<int32_t>(values[i]);
+        }
+        tensor_proto->set_raw_data(promoted.data(), promoted.size() * sizeof(int32_t));
+    }
+    else
+    {
+        std::vector<int64_t> promoted(values.begin(), values.end());
+        tensor_proto->set_raw_data(promoted.data(), promoted.size() * sizeof(int64_t));
+    }
+    index.NoteInitializer(*tensor_proto);
+    return tensor_proto;
+}
+
+bool TryReadIntegerTensorData(const onnx::TensorProto& tensor, std::vector<int64_t>& values)
+{
+    TensorDataView data_view;
+    if (!TryGetTensorDataView(tensor, data_view))
+    {
+        return false;
+    }
+
+    const size_t element_count = GetTensorElementCount(tensor);
+    values.resize(element_count);
+    switch (tensor.data_type())
+    {
+        case onnx::TensorProto_DataType_INT8:
+        {
+            const auto* source = static_cast<const int8_t*>(data_view.data);
+            for (size_t i = 0; i < element_count; ++i) values[i] = source[i];
+            return true;
+        }
+        case onnx::TensorProto_DataType_UINT8:
+        {
+            const auto* source = static_cast<const uint8_t*>(data_view.data);
+            for (size_t i = 0; i < element_count; ++i) values[i] = source[i];
+            return true;
+        }
+        case onnx::TensorProto_DataType_INT16:
+        {
+            const auto* source = static_cast<const int16_t*>(data_view.data);
+            for (size_t i = 0; i < element_count; ++i) values[i] = source[i];
+            return true;
+        }
+        case onnx::TensorProto_DataType_UINT16:
+        {
+            const auto* source = static_cast<const uint16_t*>(data_view.data);
+            for (size_t i = 0; i < element_count; ++i) values[i] = source[i];
+            return true;
+        }
+        case onnx::TensorProto_DataType_INT32:
+        {
+            const auto* source = static_cast<const int32_t*>(data_view.data);
+            for (size_t i = 0; i < element_count; ++i) values[i] = source[i];
+            return true;
+        }
+        case onnx::TensorProto_DataType_UINT32:
+        {
+            const auto* source = static_cast<const uint32_t*>(data_view.data);
+            for (size_t i = 0; i < element_count; ++i) values[i] = static_cast<int64_t>(source[i]);
+            return true;
+        }
+        case onnx::TensorProto_DataType_INT64:
+        {
+            const auto* source = static_cast<const int64_t*>(data_view.data);
+            values.assign(source, source + element_count);
+            return true;
+        }
+        case onnx::TensorProto_DataType_UINT64:
+        {
+            const auto* source = static_cast<const uint64_t*>(data_view.data);
+            for (size_t i = 0; i < element_count; ++i) values[i] = static_cast<int64_t>(source[i]);
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+bool TryReadFloatingTensorData(const onnx::TensorProto& tensor, std::vector<double>& values)
+{
+    TensorDataView data_view;
+    if (!TryGetTensorDataView(tensor, data_view))
+    {
+        return false;
+    }
+
+    const size_t element_count = GetTensorElementCount(tensor);
+    values.resize(element_count);
+    switch (tensor.data_type())
+    {
+        case onnx::TensorProto_DataType_FLOAT:
+        {
+            const auto* source = static_cast<const float*>(data_view.data);
+            for (size_t i = 0; i < element_count; ++i) values[i] = static_cast<double>(source[i]);
+            return true;
+        }
+        case onnx::TensorProto_DataType_DOUBLE:
+        {
+            const auto* source = static_cast<const double*>(data_view.data);
+            values.assign(source, source + element_count);
+            return true;
+        }
+        case onnx::TensorProto_DataType_FLOAT16:
+        {
+            const auto* source = static_cast<const uint16_t*>(data_view.data);
+            for (size_t i = 0; i < element_count; ++i) values[i] = static_cast<double>(Float16BitsToFloat(source[i]));
+            return true;
+        }
+        case onnx::TensorProto_DataType_BFLOAT16:
+        {
+            const auto* source = static_cast<const uint16_t*>(data_view.data);
+            for (size_t i = 0; i < element_count; ++i) values[i] = static_cast<double>(BFloat16BitsToFloat(source[i]));
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+// ONNX requires Q/DQ scales to be strictly positive and finite. Zero or
+// negative scales make the lowered arithmetic ill-defined (Div->inf/NaN,
+// clamp bounds flip), and NaN/Inf contaminate everything downstream.
+//
+// We don't try to "rescue" bad scales -- the caller bails out of lowering
+// and lets TRT (or ORT validation) be the one to reject a malformed node.
+bool IsPositiveScaleTensor(const onnx::TensorProto& tensor)
+{
+    std::vector<double> values;
+    if (!TryReadFloatingTensorData(tensor, values) || values.empty())
+    {
+        return false;
+    }
+    return std::all_of(values.begin(), values.end(), [](double value) { return value > 0.0 && std::isfinite(value); });
+}
+
+// Given a flat output element index, work out which flat index of the
+// scale/zp parameter tensor it should read from.
+//
+// Handles all three Q/DQ broadcasting flavors the ONNX spec defines:
+//   * per-tensor              : parameter rank 0 or 1 element -> index 0
+//   * per-axis (1-D)          : parameter matches one input axis (default
+//                               axis=1, negative axes normalized)
+//   * block quantization      : parameter along `axis` is (input_dim /
+//                               block_size); floor-divide the input axis
+//                               coordinate by block_size to find the
+//                               parameter coordinate.
+//   * full-rank broadcast     : parameter rank == input rank with each dim
+//                               either equal to the input or 1.
+//
+// Returns false if shapes are inconsistent with any of the above; the caller
+// treats that as "unsupported layout, leave node native" rather than guessing.
+bool TryResolveBroadcastIndex(size_t element_index, const onnx::TensorProto& input_tensor,
+                              const onnx::TensorProto& parameter_tensor, std::optional<int64_t> axis_attr,
+                              int64_t block_size, size_t& parameter_index)
+{
+    std::vector<int64_t> input_shape(input_tensor.dims().begin(), input_tensor.dims().end());
+    const size_t input_rank = input_shape.size();
+    const size_t parameter_rank = static_cast<size_t>(parameter_tensor.dims_size());
+    const size_t parameter_elements = GetTensorElementCount(parameter_tensor);
+    if (parameter_rank == 0 || parameter_elements == 1)
+    {
+        parameter_index = 0;
+        return true;
+    }
+
+    int64_t axis = axis_attr.value_or(1);
+    if (axis < 0)
+    {
+        axis += static_cast<int64_t>(input_rank);
+    }
+    if ((parameter_rank == 1 && input_rank > 1) && (axis < 0 || axis >= static_cast<int64_t>(input_rank)))
+    {
+        return false;
+    }
+
+    std::vector<size_t> input_strides(input_rank, 1);
+    for (size_t dim = input_rank; dim-- > 1;)
+    {
+        input_strides[dim - 1] = input_strides[dim] * static_cast<size_t>(input_shape[dim]);
+    }
+
+    std::vector<size_t> parameter_strides(parameter_rank == 0 ? 1 : parameter_rank, 1);
+    if (parameter_rank > 1)
+    {
+        for (size_t dim = parameter_rank; dim-- > 1;)
+        {
+            parameter_strides[dim - 1] =
+                parameter_strides[dim] * static_cast<size_t>(parameter_tensor.dims(static_cast<int>(dim)));
+        }
+    }
+
+    std::vector<size_t> input_indices(input_rank, 0);
+    size_t remaining_index = element_index;
+    for (size_t dim = 0; dim < input_rank; ++dim)
+    {
+        const size_t stride = input_strides[dim];
+        input_indices[dim] = remaining_index / stride;
+        remaining_index %= stride;
+    }
+
+    if (parameter_rank == 1)
+    {
+        if (input_rank <= 1)
+        {
+            const int64_t input_dim = input_shape.empty() ? 1 : input_shape[0];
+            const int64_t parameter_dim = parameter_tensor.dims(0);
+            if (parameter_dim == input_dim)
+            {
+                parameter_index = input_indices.empty() ? 0 : input_indices[0];
+                return true;
+            }
+            if (parameter_dim == 1)
+            {
+                parameter_index = 0;
+                return true;
+            }
+            if (block_size > 1 && parameter_dim > 0 && parameter_dim * block_size == input_dim)
+            {
+                parameter_index = (input_indices.empty() ? 0 : input_indices[0]) / static_cast<size_t>(block_size);
+                return parameter_index < parameter_elements;
+            }
+            return false;
+        }
+
+        const size_t axis_index = static_cast<size_t>(axis);
+        const int64_t parameter_dim = parameter_tensor.dims(0);
+        const int64_t input_dim = input_shape[axis_index];
+        size_t logical_index = input_indices[axis_index];
+        if (block_size > 1)
+        {
+            if (parameter_dim <= 0 || parameter_dim * block_size != input_dim)
+            {
+                return false;
+            }
+            logical_index /= static_cast<size_t>(block_size);
+        }
+        else if (parameter_dim != 1 && parameter_dim != input_dim)
+        {
+            return false;
+        }
+
+        parameter_index = parameter_dim == 1 ? 0 : logical_index;
+        return parameter_index < parameter_elements;
+    }
+
+    if (parameter_rank != input_rank)
+    {
+        return false;
+    }
+
+    parameter_index = 0;
+    for (size_t dim = 0; dim < input_rank; ++dim)
+    {
+        const int64_t parameter_dim = parameter_tensor.dims(static_cast<int>(dim));
+        const int64_t input_dim = input_shape[dim];
+        size_t logical_index = input_indices[dim];
+
+        if (dim == static_cast<size_t>(axis) && block_size > 1)
+        {
+            if (parameter_dim > 0 && parameter_dim * block_size == input_dim)
+            {
+                logical_index /= static_cast<size_t>(block_size);
+            }
+            else if (parameter_dim != 1 && parameter_dim != input_dim)
+            {
+                return false;
+            }
+        }
+        else if (parameter_dim != 1 && parameter_dim != input_dim)
+        {
+            return false;
+        }
+
+        parameter_index += (parameter_dim == 1 ? 0 : logical_index) * parameter_strides[dim];
+    }
+
+    return parameter_index < parameter_elements;
+}
+
+// Emits a lowered helper node inheriting the source Q/DQ node's doc_string.
+//
+// CRITICAL INVARIANT: doc_string carries the original ORT node id (written
+// by the provider's OrtGraphToProto handler). Every lowered helper MUST
+// propagate it so the provider's build_proto_to_ort_index remap can credit
+// supported-set membership back to the correct ORT node. Initializers we add
+// (qmin, qmax, reshaped scale, promoted zp) are not NodeProtos and do not
+// carry doc_string, which is intentional -- only executable nodes are
+// subject to the parser's support decision.
+onnx::NodeProto* AppendNode(google::protobuf::RepeatedPtrField<onnx::NodeProto>& nodes,
+                            const onnx::NodeProto& source_node, const std::string& op_type, const std::string& name,
+                            const std::vector<std::string>& inputs, const std::vector<std::string>& outputs)
+{
+    auto* new_node = nodes.Add();
+    new_node->set_name(name);
+    new_node->set_domain(kMainOnnxDomain);
+    new_node->set_op_type(op_type);
+    new_node->set_doc_string(source_node.doc_string());
+    for (const auto& input : inputs)
+    {
+        new_node->add_input(input);
+    }
+    for (const auto& output : outputs)
+    {
+        new_node->add_output(output);
+    }
+    return new_node;
+}
+
+void CopyNodeAttributes(const onnx::NodeProto& source_node, onnx::NodeProto& target_node)
+{
+    target_node.mutable_attribute()->CopyFrom(source_node.attribute());
+}
+
+bool TryGetQuantizedValueRange(int32_t data_type, int64_t& min_value, int64_t& max_value)
+{
+    switch (data_type)
+    {
+        case onnx::TensorProto_DataType_INT8:
+            min_value = -128;
+            max_value = 127;
+            return true;
+        case onnx::TensorProto_DataType_UINT8:
+            min_value = 0;
+            max_value = 255;
+            return true;
+        case onnx::TensorProto_DataType_INT16:
+            min_value = std::numeric_limits<int16_t>::min();
+            max_value = std::numeric_limits<int16_t>::max();
+            return true;
+        case onnx::TensorProto_DataType_UINT16:
+            min_value = 0;
+            max_value = std::numeric_limits<uint16_t>::max();
+            return true;
+        case onnx::TensorProto_DataType_INT32:
+            min_value = std::numeric_limits<int32_t>::min();
+            max_value = std::numeric_limits<int32_t>::max();
+            return true;
+        case onnx::TensorProto_DataType_UINT32:
+            min_value = 0;
+            max_value = static_cast<int64_t>(std::numeric_limits<uint32_t>::max());
+            return true;
+        default:
+            return false;
+    }
+}
+
+// Pre-expand a per-axis or block-quantized scale/zp initializer to the
+// input's full shape.
+//
+// Why we expand at compile time rather than emit a runtime Expand:
+//   * Block-quant broadcasting (param_dim * block_size == input_dim along
+//     `axis`) is NOT a standard ONNX Expand pattern; no TRT-supported op
+//     encodes "repeat each row block_size times along axis N".
+//   * Expanded initializer bytes are small for the Q/DQ cases we lower
+//     (weights scales, channel/block scales), so the memory cost is modest.
+//   * Keeping it as an initializer lets TRT constant-fold into weights
+//     without any runtime cost.
+onnx::TensorProto* AddExpandedInitializer(onnx::GraphProto& graph, GraphIndex& index, const std::string& name,
+                                          const onnx::TensorProto& source_tensor,
+                                          const std::vector<int64_t>& input_shape,
+                                          std::optional<int64_t> axis_attr, int64_t block_size)
+{
+    TensorDataView data_view;
+    if (!TryGetTensorDataView(source_tensor, data_view))
+    {
+        return nullptr;
+    }
+
+    const size_t element_size = GetTensorElementSize(source_tensor.data_type());
+    if (element_size == 0)
+    {
+        return nullptr;
+    }
+
+    onnx::TensorProto input_shape_tensor;
+    input_shape_tensor.set_data_type(source_tensor.data_type());
+    for (const auto dim : input_shape)
+    {
+        input_shape_tensor.add_dims(dim);
+    }
+
+    const size_t output_count = GetTensorElementCount(input_shape_tensor);
+    std::string expanded_raw_data;
+    expanded_raw_data.resize(output_count * element_size);
+    for (size_t i = 0; i < output_count; ++i)
+    {
+        size_t parameter_index = 0;
+        if (!TryResolveBroadcastIndex(i, input_shape_tensor, source_tensor, axis_attr, block_size, parameter_index))
+        {
+            return nullptr;
+        }
+        std::memcpy(expanded_raw_data.data() + i * element_size,
+                    static_cast<const uint8_t*>(data_view.data) + parameter_index * element_size, element_size);
+    }
+
+    auto* tensor_proto = graph.add_initializer();
+    tensor_proto->set_name(name);
+    tensor_proto->set_data_type(source_tensor.data_type());
+    tensor_proto->set_data_location(onnx::TensorProto_DataLocation_DEFAULT);
+    for (const auto dim : input_shape)
+    {
+        tensor_proto->add_dims(dim);
+    }
+    tensor_proto->set_raw_data(expanded_raw_data.data(), expanded_raw_data.size());
+    index.NoteInitializer(*tensor_proto);
+    return tensor_proto;
+}
+
+// Prepare the scale / zero_point input for the lowered Mul / Div / Sub / Add
+// so that standard ONNX right-aligned broadcasting reproduces Q/DQ semantics:
+//
+//   * Per-tensor (scalar / single-element parameter): no reshape needed.
+//   * Block quantization (block_size > 1): eagerly expand the initializer
+//     via AddExpandedInitializer (standard broadcast cannot express it).
+//   * Per-axis on the *last* axis: no reshape -- ONNX broadcasting already
+//     aligns a 1-D tensor to the last axis.
+//   * Per-axis on any other axis: emit a Reshape that places the parameter
+//     dim at `axis` and 1s elsewhere, so downstream broadcasts correctly.
+//   * Full-rank parameter: accepted as-is only when rank matches input rank;
+//     unusual ONNX layouts fall through as "unsupported, keep native".
+bool MaybeAddAxisReshape(onnx::GraphProto& graph, GraphIndex& index,
+                         google::protobuf::RepeatedPtrField<onnx::NodeProto>& nodes,
+                         const onnx::NodeProto& source_node, const std::string& input_name,
+                         const std::string& base_name, std::optional<int64_t> input_rank,
+                         std::optional<int64_t> axis_attr, const onnx::TensorProto& parameter_tensor,
+                         int64_t block_size, size_t unique_id, std::string& broadcast_name)
+{
+    broadcast_name = input_name;
+    const size_t parameter_rank = static_cast<size_t>(parameter_tensor.dims_size());
+    const size_t parameter_elements = GetTensorElementCount(parameter_tensor);
+    if (parameter_rank == 0 || parameter_elements == 1)
+    {
+        return true;
+    }
+
+    if (!input_rank)
+    {
+        return false;
+    }
+
+    if (block_size > 1)
+    {
+        std::vector<int64_t> input_shape;
+        if (!index.TryGetTensorShape(source_node.input(0), input_shape))
+        {
+            return false;
+        }
+        const std::string expanded_name = MakeLoweredName(base_name, "expanded", unique_id);
+        if (AddExpandedInitializer(graph, index, expanded_name, parameter_tensor, input_shape, axis_attr, block_size) == nullptr)
+        {
+            return false;
+        }
+        broadcast_name = expanded_name;
+        return true;
+    }
+
+    if (parameter_rank == 1)
+    {
+        if (*input_rank <= 1)
+        {
+            return true;
+        }
+
+        int64_t axis = axis_attr.value_or(1);
+        if (axis < 0)
+        {
+            axis += *input_rank;
+        }
+        if (axis < 0 || axis >= *input_rank)
+        {
+            return false;
+        }
+        if (axis == *input_rank - 1)
+        {
+            return true;
+        }
+
+        std::vector<int64_t> reshape_dims(static_cast<size_t>(*input_rank), 1);
+        reshape_dims[static_cast<size_t>(axis)] = parameter_tensor.dims(0);
+        const std::string shape_name = MakeLoweredName(base_name, "reshape_shape", unique_id);
+        const std::string reshaped_name = MakeLoweredName(base_name, "reshaped", unique_id);
+        AddInt64VectorInitializer(graph, index, shape_name, reshape_dims);
+        AppendNode(nodes, source_node, "Reshape", MakeLoweredName(base_name, "reshape", unique_id),
+                   {input_name, shape_name}, {reshaped_name});
+        broadcast_name = reshaped_name;
+        return true;
+    }
+
+    return parameter_rank == static_cast<size_t>(*input_rank);
+}
+
+// Constant-weight DQ folding.
+//
+// When the DQ input is itself an initializer, we precompute y = (x - zp) *
+// scale offline and emit a float initializer carrying those bytes. We then
+// append a trivial Identity(folded_initializer -> original_output_name) so
+// downstream consumers don't need to be rewired.
+//
+// Why keep the Identity instead of renaming the initializer:
+//   1. The original output name may appear elsewhere in the graph (graph
+//      outputs, other consumers); renaming would require a full sweep.
+//   2. The Identity carries the original ORT node's doc_string, so the
+//      provider's proto->ORT remap can still credit this ORT node. If TRT
+//      prunes the Identity as trivial, we also record the fold in
+//      LoweredQdqInfo::folded_constant_nodes so the provider can reattach
+//      the original ORT node to whatever parser subgraph still references
+//      the folded tensor (see the reattachment loop in GetSupportedList).
+bool TryFoldConstantDequantizeLinear(onnx::GraphProto& graph, GraphIndex& index,
+                                     google::protobuf::RepeatedPtrField<onnx::NodeProto>& nodes,
+                                     const onnx::NodeProto& node, const onnx::TensorProto& input_tensor,
+                                     const onnx::TensorProto& scale_tensor, const onnx::TensorProto* zero_point_tensor,
+                                     int32_t arithmetic_type, std::optional<int64_t> axis_attr, int64_t block_size,
+                                     size_t& unique_id, LoweredQdqInfo& lowered_qdq_info)
+{
+    // Only fp32/fp64 folding is safe; fp16/bf16 folding would lose precision
+    // relative to what the runtime path would have produced.
+    if (arithmetic_type != onnx::TensorProto_DataType_FLOAT &&
+        arithmetic_type != onnx::TensorProto_DataType_DOUBLE)
+    {
+        return false;
+    }
+
+    std::vector<int64_t> input_values;
+    std::vector<double> scale_values;
+    std::vector<int64_t> zero_point_values;
+    if (!TryReadIntegerTensorData(input_tensor, input_values) || !TryReadFloatingTensorData(scale_tensor, scale_values))
+    {
+        return false;
+    }
+    if (zero_point_tensor != nullptr && !TryReadIntegerTensorData(*zero_point_tensor, zero_point_values))
+    {
+        return false;
+    }
+
+    const size_t element_count = input_values.size();
+    const std::string folded_output_name = MakeLoweredName(node.output(0), "folded_constant", ++unique_id);
+    auto* tensor_proto = graph.add_initializer();
+    tensor_proto->set_name(folded_output_name);
+    tensor_proto->set_data_type(arithmetic_type);
+    tensor_proto->set_data_location(onnx::TensorProto_DataLocation_DEFAULT);
+    for (const auto dim : input_tensor.dims())
+    {
+        tensor_proto->add_dims(dim);
+    }
+
+    if (arithmetic_type == onnx::TensorProto_DataType_FLOAT)
+    {
+        std::vector<float> output_values(element_count);
+        for (size_t i = 0; i < element_count; ++i)
+        {
+            size_t scale_index = 0;
+            size_t zero_index = 0;
+            if (!TryResolveBroadcastIndex(i, input_tensor, scale_tensor, axis_attr, block_size, scale_index))
+            {
+                return false;
+            }
+            if (zero_point_tensor != nullptr &&
+                !TryResolveBroadcastIndex(i, input_tensor, *zero_point_tensor, axis_attr, block_size, zero_index))
+            {
+                return false;
+            }
+            const double zero_point = zero_point_tensor != nullptr ? static_cast<double>(zero_point_values[zero_index]) : 0.0;
+            output_values[i] = static_cast<float>((static_cast<double>(input_values[i]) - zero_point) * scale_values[scale_index]);
+        }
+        tensor_proto->set_raw_data(output_values.data(), output_values.size() * sizeof(float));
+    }
+    else
+    {
+        std::vector<double> output_values(element_count);
+        for (size_t i = 0; i < element_count; ++i)
+        {
+            size_t scale_index = 0;
+            size_t zero_index = 0;
+            if (!TryResolveBroadcastIndex(i, input_tensor, scale_tensor, axis_attr, block_size, scale_index))
+            {
+                return false;
+            }
+            if (zero_point_tensor != nullptr &&
+                !TryResolveBroadcastIndex(i, input_tensor, *zero_point_tensor, axis_attr, block_size, zero_index))
+            {
+                return false;
+            }
+            const double zero_point = zero_point_tensor != nullptr ? static_cast<double>(zero_point_values[zero_index]) : 0.0;
+            output_values[i] = (static_cast<double>(input_values[i]) - zero_point) * scale_values[scale_index];
+        }
+        tensor_proto->set_raw_data(output_values.data(), output_values.size() * sizeof(double));
+    }
+    index.NoteInitializer(*tensor_proto);
+
+    AppendNode(nodes, node, "Identity", MakeLoweredName(node.output(0), "folded_identity", ++unique_id),
+               {folded_output_name}, {node.output(0)});
+    if (auto node_id = TryParseNodeId(node.doc_string()))
+    {
+        lowered_qdq_info.folded_constant_nodes.push_back({*node_id, node.output(0)});
+    }
+    return true;
+}
+
+// Policy: the lowered arithmetic carries the scale's own floating dtype.
+// Rationale:
+//   * The final Mul/Div requires same-type operands as the scale, so any
+//     other choice forces an extra Cast with no numerical benefit.
+//   * Model authors pick scale dtype deliberately (fp16 scales for fp16
+//     pipelines, fp32 otherwise); respect that choice.
+// Exceptions are handled in GetQuantizeArithmeticType (int16/uint16 outputs
+// need fp32 even when the scale is fp16/bf16).
+std::optional<int32_t> GetArithmeticTypeForScale(const onnx::TensorProto& scale_tensor)
+{
+    switch (scale_tensor.data_type())
+    {
+        case onnx::TensorProto_DataType_FLOAT:
+        case onnx::TensorProto_DataType_FLOAT16:
+        case onnx::TensorProto_DataType_BFLOAT16:
+        case onnx::TensorProto_DataType_DOUBLE:
+            return scale_tensor.data_type();
+        default:
+            return std::nullopt;
+    }
+}
+
+// "Asymmetric" is only asymmetric if the zp tensor exists AND carries at
+// least one non-zero element. An absent zp (no input or empty-string input)
+// and a zp initializer full of zeros are both treated as symmetric (zp=0).
+bool HasExplicitNonZeroZeroPoint(const onnx::TensorProto* zero_point_tensor)
+{
+    return zero_point_tensor != nullptr && TensorHasAnyNonZeroValue(*zero_point_tensor);
+}
+
+// Native ONNX integer zero_point types (int8/uint8/int16/uint16) cannot be
+// Sub'd from a widened integer (or Cast'd to a float) directly in a way that
+// both TRT and ORT accept as input dtypes to Sub/Cast. Promote to int32 (or
+// int64 when the arithmetic is double-precision) so the lowered Sub/Add is
+// always in a widely-supported dtype.
+bool NeedsPromotedZeroPoint(int32_t zero_point_type)
+{
+    return zero_point_type != onnx::TensorProto_DataType_INT32 && zero_point_type != onnx::TensorProto_DataType_INT64;
+}
+
+// Choose the promoted zero_point container type:
+//   * INT64 zp stays INT64 (already widest).
+//   * UINT32 zp -> INT64 so the signed Sub cannot overflow at the high end.
+//   * INT32 zp stays INT32.
+//   * Low-bit integer zp -> INT32 normally, INT64 only when arithmetic is
+//     double (to keep the Cast chain precision-consistent).
+int32_t GetPromotedZeroPointType(int32_t zero_point_type, int32_t arithmetic_type)
+{
+    if (zero_point_type == onnx::TensorProto_DataType_INT64)
+    {
+        return onnx::TensorProto_DataType_INT64;
+    }
+    if (zero_point_type == onnx::TensorProto_DataType_UINT32)
+    {
+        return onnx::TensorProto_DataType_INT64;
+    }
+    if (zero_point_type == onnx::TensorProto_DataType_INT32)
+    {
+        return onnx::TensorProto_DataType_INT32;
+    }
+    if (zero_point_type == onnx::TensorProto_DataType_UINT16 || zero_point_type == onnx::TensorProto_DataType_UINT8 ||
+        zero_point_type == onnx::TensorProto_DataType_INT16 || zero_point_type == onnx::TensorProto_DataType_INT8)
+    {
+        return arithmetic_type == onnx::TensorProto_DataType_DOUBLE ? onnx::TensorProto_DataType_INT64
+                                                                    : onnx::TensorProto_DataType_INT32;
+    }
+    return zero_point_type;
+}
+
+// For int32/uint32 DequantizeLinear, do the (x - zp) subtraction in INT64
+// *before* casting to float. Converting uint32 values straight to fp32 loses
+// up to 8 bits of precision and makes the subsequent Sub inexact; widening to
+// int64 first preserves the exact integer difference, and only then we cast
+// to the scale's floating dtype for the final Mul.
+//
+// Low-bit integers (int8/uint8/int16/uint16) fit exactly in fp32, so they
+// skip this stage and cast directly to arithmetic_type in one step.
+std::optional<int32_t> GetDequantizeIntegerMathType(int32_t input_type)
+{
+    switch (input_type)
+    {
+        case onnx::TensorProto_DataType_INT32:
+        case onnx::TensorProto_DataType_UINT32:
+            return onnx::TensorProto_DataType_INT64;
+        default:
+            return std::nullopt;
+    }
+}
+
+// Choose the arithmetic dtype for a lowered QuantizeLinear.
+//
+// Default: inherit the scale's dtype (same rationale as GetArithmeticTypeForScale).
+//
+// Special case: int16/uint16 output with fp16/bf16 scale MUST be promoted
+// to fp32. The 16-bit integer clamp bounds are +/-32768, far outside the
+// exactly-representable range of fp16 (max ~65504 but with spacing >32 near
+// the top) and bf16 (spacing 256 near the top). Doing round(x/scale)+zp and
+// the final Max/Min in fp16/bf16 would round qmax to inf or snap rounded
+// values to the wrong integer, producing silently-wrong quantization.
+std::optional<int32_t> GetQuantizeArithmeticType(const onnx::TensorProto& scale_tensor, int32_t output_type)
+{
+    auto arithmetic_type = GetArithmeticTypeForScale(scale_tensor);
+    if (!arithmetic_type)
+    {
+        return std::nullopt;
+    }
+
+    if ((output_type == onnx::TensorProto_DataType_INT16 || output_type == onnx::TensorProto_DataType_UINT16) &&
+        (*arithmetic_type == onnx::TensorProto_DataType_FLOAT16 ||
+         *arithmetic_type == onnx::TensorProto_DataType_BFLOAT16))
+    {
+        return onnx::TensorProto_DataType_FLOAT;
+    }
+
+    return arithmetic_type;
+}
+
+struct QdqLoweringDecision
+{
+    bool should_lower = false;
+    std::string reason;
+};
+
+bool ShouldLowerQuantizeLinear(const onnx::NodeProto& node, const onnx::TensorProto& scale_tensor,
+                               const onnx::TensorProto* zero_point_tensor, int32_t output_type);
+
+std::string NodeDisplayName(const onnx::NodeProto& node)
+{
+    if (!node.name().empty())
+    {
+        return node.name();
+    }
+    if (node.output_size() > 0 && !node.output(0).empty())
+    {
+        return node.output(0);
+    }
+    return node.op_type();
+}
+
+std::string TensorDataTypeToString(int32_t data_type)
+{
+    switch (data_type)
+    {
+        case onnx::TensorProto_DataType_INT8:
+            return "int8";
+        case onnx::TensorProto_DataType_UINT8:
+            return "uint8";
+        case onnx::TensorProto_DataType_INT16:
+            return "int16";
+        case onnx::TensorProto_DataType_UINT16:
+            return "uint16";
+        case onnx::TensorProto_DataType_INT32:
+            return "int32";
+        case onnx::TensorProto_DataType_UINT32:
+            return "uint32";
+        case onnx::TensorProto_DataType_FLOAT16:
+            return "float16";
+        case onnx::TensorProto_DataType_BFLOAT16:
+            return "bfloat16";
+        case onnx::TensorProto_DataType_FLOAT:
+            return "float32";
+        case onnx::TensorProto_DataType_DOUBLE:
+            return "float64";
+        default:
+            return std::to_string(data_type);
+    }
+}
+
+// Ops that TRT treats as Q/DQ fusion anchors. The harmonization rule only
+// kicks in around these, because those are the ops where TRT's Q/DQ fuser
+// has a meaningful "either fully-native or fully-lowered" preference. For
+// other ops (e.g. Add, Concat, Transpose) leaving a mixed neighborhood is
+// harmless -- no fusion opportunity is lost.
+bool IsComputeAnchorOp(const onnx::NodeProto& node)
+{
+    return node.op_type() == "Gemm" || node.op_type() == "MatMul" || node.op_type() == "Conv" ||
+           node.op_type() == "ConvTranspose";
+}
+
+// Base (unconditional) DQ lowering rules. These fire regardless of whether
+// the DQ is around a compute anchor; harmonization is layered on top.
+//
+//   DQ-1: explicit non-zero zero_point  -> TRT native DQ is symmetric-only.
+//   DQ-2: int32/uint32 input            -> TRT native DQ does not accept
+//                                          those integer widths.
+//
+// `reason` is populated so the harmonization layer and diagnostics can
+// attribute decisions back to a specific rule.
+bool BaseMustLowerDequantize(const onnx::TensorProto* zero_point_tensor, int32_t input_type, std::string& reason)
+{
+    if (HasExplicitNonZeroZeroPoint(zero_point_tensor))
+    {
+        reason = "explicit non-zero zeroPoint";
+        return true;
+    }
+    if (IsTensorRtUnsupportedQdqIntegerType(input_type))
+    {
+        reason = "native TensorRT DequantizeLinear does not support input type " + TensorDataTypeToString(input_type);
+        return true;
+    }
+    return false;
+}
+
+QdqLoweringDecision EvaluateBaseDequantizeLowering(const onnx::NodeProto& node, const GraphIndex& index)
+{
+    if (node.input_size() < 2)
+    {
+        return {};
+    }
+
+    const auto* scale_tensor = index.FindInitializer(node.input(1));
+    if (scale_tensor == nullptr || !IsPositiveScaleTensor(*scale_tensor))
+    {
+        return {};
+    }
+
+    const auto input_type = index.FindTensorElementType(node.input(0));
+    if (!input_type)
+    {
+        return {};
+    }
+
+    const auto* zero_point_tensor =
+        (node.input_size() > 2 && !node.input(2).empty()) ? index.FindInitializer(node.input(2)) : nullptr;
+
+    QdqLoweringDecision decision;
+    decision.should_lower = BaseMustLowerDequantize(zero_point_tensor, *input_type, decision.reason);
+    return decision;
+}
+
+QdqLoweringDecision EvaluateBaseQuantizeLowering(const onnx::NodeProto& node, const GraphIndex& index)
+{
+    if (node.input_size() < 2)
+    {
+        return {};
+    }
+
+    const auto* scale_tensor = index.FindInitializer(node.input(1));
+    if (scale_tensor == nullptr || !IsPositiveScaleTensor(*scale_tensor))
+    {
+        return {};
+    }
+
+    const auto* zero_point_tensor =
+        (node.input_size() > 2 && !node.input(2).empty()) ? index.FindInitializer(node.input(2)) : nullptr;
+
+    int32_t output_type = zero_point_tensor != nullptr ? zero_point_tensor->data_type() : onnx::TensorProto_DataType_UINT8;
+    if (zero_point_tensor == nullptr)
+    {
+        if (auto output_dtype = FindIntAttribute(node, "output_dtype"))
+        {
+            output_type = static_cast<int32_t>(*output_dtype);
+        }
+    }
+
+    QdqLoweringDecision decision;
+    if (ShouldLowerQuantizeLinear(node, *scale_tensor, zero_point_tensor, output_type))
+    {
+        decision.should_lower = true;
+        decision.reason = "explicit non-zero zeroPoint";
+    }
+    return decision;
+}
+
+// A "symmetric constant DQ" is the shape TRT wants to keep native:
+//   * zp is absent / all-zero,
+//   * input type is one TRT accepts (no int32/uint32),
+//   * the DQ input is a compile-time initializer (i.e. a weight, not an
+//     activation -- graph inputs are explicitly excluded).
+// Only candidates that pass this filter are eligible for the harmonization
+// rule below. Everything else is already covered by the base rules.
+bool IsSymmetricConstantDequantizeCandidate(const onnx::NodeProto& node, const GraphIndex& index,
+                                            const onnx::TensorProto* zero_point_tensor, int32_t input_type)
+{
+    if (node.input_size() < 1 || node.input(0).empty())
+    {
+        return false;
+    }
+    if (HasExplicitNonZeroZeroPoint(zero_point_tensor) || IsTensorRtUnsupportedQdqIntegerType(input_type))
+    {
+        return false;
+    }
+    if (index.IsGraphInput(node.input(0)))
+    {
+        return false;
+    }
+    return index.FindInitializer(node.input(0)) != nullptr;
+}
+
+const onnx::NodeProto* FindSingleConsumerAnchor(const onnx::NodeProto& node, const GraphIndex& index)
+{
+    // Symmetric constant DQ stays native by default. We only harmonize it when a
+    // single downstream compute anchor would otherwise mix native and lowered Q/DQ
+    // paths in the same local neighborhood.
+    if (node.output_size() == 0 || node.output(0).empty())
+    {
+        return nullptr;
+    }
+
+    const auto* consumer_indices = index.FindConsumerNodeIndices(node.output(0));
+    if (consumer_indices == nullptr || consumer_indices->size() != 1)
+    {
+        return nullptr;
+    }
+
+    const auto* anchor = index.GetNode((*consumer_indices)[0]);
+    if (anchor == nullptr || !IsComputeAnchorOp(*anchor))
+    {
+        return nullptr;
+    }
+    return anchor;
+}
+
+// Harmonization check around a compute anchor.
+//
+// Problem: a Gemm/MatMul/Conv typically sits at the center of a Q/DQ cluster:
+//
+//    weight_const --(sym DQ int8)----\
+//                                      Gemm --(asym Q uint8)--> ...
+//    input_act    --(asym DQ uint8)--/
+//
+// If we keep the symmetric weight DQ native but lower the asymmetric
+// activation DQ and output Q, TRT's fuser is left with a mixed neighborhood
+// (half native Q/DQ, half plain arithmetic) and cannot apply its integer
+// Gemm fusion. Perf collapses and numerics become harder to reason about.
+//
+// Rule: if ANY sibling Q/DQ attached to the same anchor is already forced
+// to lower by the base rules, the symmetric constant DQ is lowered too so
+// the whole neighborhood is uniformly lowered arithmetic.
+//
+// We scan both sides of the anchor:
+//   * Other inputs' producers: other DQ/Q feeding the anchor.
+//   * Each output's consumers: Q ops that re-quantize the anchor's result.
+//
+// Importantly, we call the *base* evaluators on siblings, not the full
+// harmonization evaluator, to avoid mutual recursion between neighbors.
+bool AnchorHasForcedLoweringSibling(const onnx::NodeProto& candidate_node, const onnx::NodeProto& anchor,
+                                    const GraphIndex& index, std::string& reason)
+{
+    for (const auto& anchor_input : anchor.input())
+    {
+        if (anchor_input.empty())
+        {
+            continue;
+        }
+
+        const auto* producer = index.FindProducer(anchor_input);
+        if (producer == nullptr || producer == &candidate_node)
+        {
+            continue;
+        }
+
+        if (producer->op_type() == "DequantizeLinear")
+        {
+            auto sibling_decision = EvaluateBaseDequantizeLowering(*producer, index);
+            if (sibling_decision.should_lower)
+            {
+                reason = "anchor input producer '" + NodeDisplayName(*producer) + "' already lowers (" +
+                         sibling_decision.reason + ")";
+                return true;
+            }
+        }
+        else if (producer->op_type() == "QuantizeLinear")
+        {
+            auto sibling_decision = EvaluateBaseQuantizeLowering(*producer, index);
+            if (sibling_decision.should_lower)
+            {
+                reason = "anchor input producer '" + NodeDisplayName(*producer) + "' already lowers (" +
+                         sibling_decision.reason + ")";
+                return true;
+            }
+        }
+    }
+
+    for (const auto& anchor_output : anchor.output())
+    {
+        if (anchor_output.empty())
+        {
+            continue;
+        }
+
+        const auto* consumer_indices = index.FindConsumerNodeIndices(anchor_output);
+        if (consumer_indices == nullptr)
+        {
+            continue;
+        }
+
+        for (const auto consumer_index : *consumer_indices)
+        {
+            const auto* consumer = index.GetNode(consumer_index);
+            if (consumer == nullptr || consumer == &candidate_node)
+            {
+                continue;
+            }
+
+            if (consumer->op_type() == "QuantizeLinear")
+            {
+                auto sibling_decision = EvaluateBaseQuantizeLowering(*consumer, index);
+                if (sibling_decision.should_lower)
+                {
+                    reason = "anchor output consumer '" + NodeDisplayName(*consumer) + "' already lowers (" +
+                             sibling_decision.reason + ")";
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+// DequantizeLinear lowering has two stages:
+// 1. Lower asymmetric or TRT-unsupported integer types unconditionally.
+// 2. Keep symmetric constant weights native unless the surrounding compute anchor
+//    is already forced into lowered math by a sibling Q/DQ path. That avoids
+//    leaving a mixed native/lowered neighborhood around one Gemm/MatMul/Conv op.
+QdqLoweringDecision EvaluateDequantizeLowering(const onnx::NodeProto& node, const GraphIndex& index,
+                                               const onnx::TensorProto* zero_point_tensor, int32_t input_type)
+{
+    auto base_decision = EvaluateBaseDequantizeLowering(node, index);
+    if (base_decision.should_lower)
+    {
+        return base_decision;
+    }
+
+    if (!IsSymmetricConstantDequantizeCandidate(node, index, zero_point_tensor, input_type))
+    {
+        base_decision.reason = "keep native symmetric DequantizeLinear";
+        return base_decision;
+    }
+
+    const auto* anchor = FindSingleConsumerAnchor(node, index);
+    if (anchor == nullptr)
+    {
+        base_decision.reason = "keep native symmetric constant DequantizeLinear because there is no single compute anchor";
+        return base_decision;
+    }
+
+    std::string harmonization_reason;
+    if (AnchorHasForcedLoweringSibling(node, *anchor, index, harmonization_reason))
+    {
+        return {true, "harmonize symmetric constant DequantizeLinear around anchor '" + NodeDisplayName(*anchor) +
+                          "' because " + harmonization_reason};
+    }
+
+    base_decision.reason = "keep native symmetric constant DequantizeLinear because anchor '" + NodeDisplayName(*anchor) +
+                           "' has no sibling Q/DQ path that must lower";
+    return base_decision;
+}
+
+// QuantizeLinear lowering policy.
+//
+//   Q-1 (keep native): zero_point is absent or all zeros. TRT's symmetric Q
+//       path is the right fit; don't disturb it.
+//   Q-2 (never lower): output dtype is int32/uint32. A fp32/fp64 rendering
+//       of round(x/scale)+zp is NOT accurate over a 32-bit integer range
+//       (ULP gap at the top exceeds 1), so we'd rather report the node
+//       unsupported and let ORT fall back to CPU than silently miscompile.
+//   Q-3 (lower):       asymmetric quantization into int8/uint8/int16/uint16.
+//       These ranges are modeled exactly by our arithmetic (with the fp32
+//       promotion from GetQuantizeArithmeticType for the 16-bit cases).
+bool ShouldLowerQuantizeLinear(const onnx::NodeProto& node, const onnx::TensorProto& scale_tensor,
+                                const onnx::TensorProto* zero_point_tensor, int32_t output_type)
+{
+    (void)node;
+    (void)scale_tensor;
+    if (output_type == onnx::TensorProto_DataType_INT32 || output_type == onnx::TensorProto_DataType_UINT32)
+    {
+        return false;
+    }
+    if (!HasExplicitNonZeroZeroPoint(zero_point_tensor))
+    {
+        return false;
+    }
+    return output_type == onnx::TensorProto_DataType_INT8 || output_type == onnx::TensorProto_DataType_UINT8 ||
+           output_type == onnx::TensorProto_DataType_INT16 || output_type == onnx::TensorProto_DataType_UINT16;
+}
+}  // namespace
+
+LoweredQdqInfo RunQdqLoweringForTensorRt(onnx::ModelProto& model_proto)
+{
+    LoweredQdqInfo lowered_qdq_info;
+    auto& graph = *model_proto.mutable_graph();
+    GraphIndex index(graph);
+    google::protobuf::RepeatedPtrField<onnx::NodeProto> lowered_nodes;
+    size_t unique_id = 0;
+
+    // Rewrite only the Q/DQ patterns that TRT-RTX cannot consume natively.
+    //
+    // For DQ we materialize the WebNN / ONNX math explicitly:
+    //   y = (x - zero_point) * scale
+    //
+    //   before: x -- DequantizeLinear --> y
+    //   after : x -- Cast -- Sub(zp) -- Cast? -- Mul(scale) --> y
+    //
+    // Constant DQ can fold one step further to:
+    //   constant_int --(fold)--> constant_float -- Identity --> y
+    //
+    // For Q we lower the asymmetric form to the corresponding arithmetic:
+    //   y = cast(clamp(round(x / scale) + zero_point, qmin, qmax))
+    //
+    // We leave native symmetric paths in place unless harmonization is needed to
+    // avoid mixing lowered and native Q/DQ around the same compute anchor.
+    for (const auto& node : graph.node())
+    {
+        // Preflight gates. Any failure here means "this node's shape is
+        // either not Q/DQ or is outside what the rewrite layer can safely
+        // handle"; we copy it through verbatim and let TRT / ORT decide.
+        // These gates must stay in sync with the ones inside
+        // Evaluate{Base,}DequantizeLowering / EvaluateBaseQuantizeLowering,
+        // otherwise the policy layer and the rewrite layer could disagree.
+
+        if ((node.op_type() != "DequantizeLinear" && node.op_type() != "QuantizeLinear") || node.input_size() < 2)
+        {
+            *lowered_nodes.Add() = node;
+            continue;
+        }
+
+        // Gate 1: scale must be a readable, spec-compliant constant
+        // (positive and finite). See IsPositiveScaleTensor for rationale.
+        const auto* scale_tensor = index.FindInitializer(node.input(1));
+        if (scale_tensor == nullptr || !IsPositiveScaleTensor(*scale_tensor))
+        {
+            *lowered_nodes.Add() = node;
+            continue;
+        }
+
+        // zero_point is optional (symmetric case). nullptr here means "treat
+        // as zp=0"; it is NOT an error, so no bail-out on this line.
+        const auto* zero_point_tensor =
+            (node.input_size() > 2 && !node.input(2).empty()) ? index.FindInitializer(node.input(2)) : nullptr;
+
+        // Gate 2: input dtype must be known. Without it we can't pick
+        // integer-math widening (int32/uint32 -> int64) nor apply DQ-2.
+        std::optional<int32_t> input_type = index.FindTensorElementType(node.input(0));
+        if (!input_type)
+        {
+            *lowered_nodes.Add() = node;
+            continue;
+        }
+
+        // Gate 3: scale dtype must be a supported floating type. This also
+        // anchors the dtype of every arithmetic op we are about to emit.
+        const auto arithmetic_type = GetArithmeticTypeForScale(*scale_tensor);
+        if (!arithmetic_type)
+        {
+            *lowered_nodes.Add() = node;
+            continue;
+        }
+
+        const auto axis_attr = FindIntAttribute(node, "axis");
+        const int64_t block_size = FindIntAttribute(node, "block_size").value_or(0);
+        const std::string node_base = !node.name().empty() ? node.name() : node.output(0);
+
+        if (node.op_type() == "DequantizeLinear")
+        {
+            const auto dequantize_decision = EvaluateDequantizeLowering(node, index, zero_point_tensor, *input_type);
+            if (!dequantize_decision.should_lower)
+            {
+                *lowered_nodes.Add() = node;
+                continue;
+            }
+
+            if (const auto* input_initializer = index.FindInitializer(node.input(0)))
+            {
+                // Constant DQ is folded to a float initializer plus a trivial Identity so the
+                // lowered graph still exposes the original tensor name to downstream nodes.
+                if (TryFoldConstantDequantizeLinear(graph, index, lowered_nodes, node, *input_initializer, *scale_tensor,
+                                                    zero_point_tensor, *arithmetic_type, axis_attr, block_size, unique_id,
+                                                    lowered_qdq_info))
+                {
+                    ++lowered_qdq_info.lowered_node_count;
+                    continue;
+                }
+            }
+
+            // Lower DQ into standard ONNX arithmetic so TRT sees only supported
+            // float/int ops:
+            //
+            //   x_q -- DQ(scale, zp) --> y_f
+            //
+            // becomes
+            //
+            //   x_q -- Cast(input_math_type)
+            //       -- Sub(Cast(zp))
+            //       -- Cast(arithmetic_type)? 
+            //       -- Mul(scale)
+            //       --> y_f
+            //
+            // Integer-first subtraction preserves exact differences for int32/uint32
+            // before we finally cast to the floating arithmetic type used by scale.
+            std::string lowered_scale_name = node.input(1);
+            std::string lowered_zero_name = zero_point_tensor != nullptr ? node.input(2) : std::string();
+
+            if (!MaybeAddAxisReshape(graph, index, lowered_nodes, node, lowered_scale_name,
+                                     MakeLoweredName(node_base, "scale", ++unique_id), index.FindTensorRank(node.input(0)),
+                                     axis_attr, *scale_tensor, block_size, unique_id, lowered_scale_name))
+            {
+                *lowered_nodes.Add() = node;
+                continue;
+            }
+
+            if (zero_point_tensor != nullptr)
+            {
+                if (NeedsPromotedZeroPoint(zero_point_tensor->data_type()))
+                {
+                    lowered_zero_name = MakeLoweredName(node_base, "zero_promoted", ++unique_id);
+                    if (AddPromotedIntegerInitializer(graph, index, lowered_zero_name, *zero_point_tensor,
+                                                      GetPromotedZeroPointType(zero_point_tensor->data_type(), *arithmetic_type)) == nullptr)
+                    {
+                        *lowered_nodes.Add() = node;
+                        continue;
+                    }
+                }
+                if (!MaybeAddAxisReshape(graph, index, lowered_nodes, node, lowered_zero_name,
+                                         MakeLoweredName(node_base, "zero", ++unique_id), index.FindTensorRank(node.input(0)),
+                                         axis_attr, *index.FindInitializer(lowered_zero_name), block_size, unique_id, lowered_zero_name))
+                {
+                    *lowered_nodes.Add() = node;
+                    continue;
+                }
+            }
+
+            const auto integer_math_type = GetDequantizeIntegerMathType(*input_type);
+            const int32_t input_math_type = integer_math_type.value_or(*arithmetic_type);
+
+            const std::string cast_input_name = MakeLoweredName(node_base, "input_cast", ++unique_id);
+            auto* cast_input =
+                AppendNode(lowered_nodes, node, "Cast", MakeLoweredName(node_base, "cast_input", unique_id),
+                           {node.input(0)}, {cast_input_name});
+            auto* cast_input_attr = cast_input->add_attribute();
+            cast_input_attr->set_name("to");
+            cast_input_attr->set_type(onnx::AttributeProto_AttributeType_INT);
+            cast_input_attr->set_i(input_math_type);
+
+            std::string dequantized_name = cast_input_name;
+            if (!lowered_zero_name.empty())
+            {
+                const std::string cast_zero_name = MakeLoweredName(node_base, "zero_cast", ++unique_id);
+                auto* cast_zero =
+                    AppendNode(lowered_nodes, node, "Cast", MakeLoweredName(node_base, "cast_zero", unique_id),
+                               {lowered_zero_name}, {cast_zero_name});
+                auto* cast_zero_attr = cast_zero->add_attribute();
+                cast_zero_attr->set_name("to");
+                cast_zero_attr->set_type(onnx::AttributeProto_AttributeType_INT);
+                cast_zero_attr->set_i(input_math_type);
+
+                dequantized_name = MakeLoweredName(node_base, "shifted", ++unique_id);
+                AppendNode(lowered_nodes, node, "Sub", MakeLoweredName(node_base, "sub", unique_id),
+                           {cast_input_name, cast_zero_name}, {dequantized_name});
+            }
+
+            if (input_math_type != *arithmetic_type)
+            {
+                const std::string cast_diff_name = MakeLoweredName(node_base, "diff_cast", ++unique_id);
+                auto* cast_diff =
+                    AppendNode(lowered_nodes, node, "Cast", MakeLoweredName(node_base, "cast_diff", unique_id),
+                               {dequantized_name}, {cast_diff_name});
+                auto* cast_diff_attr = cast_diff->add_attribute();
+                cast_diff_attr->set_name("to");
+                cast_diff_attr->set_type(onnx::AttributeProto_AttributeType_INT);
+                cast_diff_attr->set_i(*arithmetic_type);
+                dequantized_name = cast_diff_name;
+            }
+
+            AppendNode(lowered_nodes, node, "Mul", MakeLoweredName(node_base, "mul", ++unique_id),
+                       {dequantized_name, lowered_scale_name}, {node.output(0)});
+            ++lowered_qdq_info.lowered_node_count;
+            continue;
+        }
+
+        if (node.op_type() == "QuantizeLinear")
+        {
+            int32_t output_type = zero_point_tensor != nullptr ? zero_point_tensor->data_type() : onnx::TensorProto_DataType_UINT8;
+            if (zero_point_tensor == nullptr)
+            {
+                if (auto output_dtype = FindIntAttribute(node, "output_dtype"))
+                {
+                    output_type = static_cast<int32_t>(*output_dtype);
+                }
+            }
+
+            if (ShouldLowerQuantizeLinear(node, *scale_tensor, zero_point_tensor, output_type))
+            {
+                // Lower asymmetric Q into explicit arithmetic:
+                //
+                //   x_f -- QuantizeLinear(scale, zp) --> y_q
+                //
+                // becomes
+                //
+                //   x_f -- Cast
+                //       -- Div(scale)
+                //       -- Add(zp)
+                //       -- Round
+                //       -- Clamp(qmin, qmax)
+                //       -- Cast(output_type)
+                //       --> y_q
+                //
+                // This mirrors the spec math while keeping TRT away from unsupported
+                // native asymmetric Q paths.
+                const auto quantize_arithmetic_type = GetQuantizeArithmeticType(*scale_tensor, output_type);
+                if (!quantize_arithmetic_type)
+                {
+                    *lowered_nodes.Add() = node;
+                    continue;
+                }
+
+                int64_t qmin = 0;
+                int64_t qmax = 0;
+                if (!TryGetQuantizedValueRange(output_type, qmin, qmax))
+                {
+                    *lowered_nodes.Add() = node;
+                    continue;
+                }
+
+                std::string lowered_scale_name = node.input(1);
+                std::string lowered_zero_name = zero_point_tensor != nullptr ? node.input(2) : std::string();
+                if (!MaybeAddAxisReshape(graph, index, lowered_nodes, node, lowered_scale_name,
+                                         MakeLoweredName(node_base, "scale", ++unique_id), index.FindTensorRank(node.input(0)),
+                                         axis_attr, *scale_tensor, block_size, unique_id, lowered_scale_name))
+                {
+                    *lowered_nodes.Add() = node;
+                    continue;
+                }
+
+                if (*quantize_arithmetic_type != scale_tensor->data_type())
+                {
+                    const std::string cast_scale_name = MakeLoweredName(node_base, "scale_cast", ++unique_id);
+                    auto* cast_scale =
+                        AppendNode(lowered_nodes, node, "Cast", MakeLoweredName(node_base, "cast_scale", unique_id),
+                                   {lowered_scale_name}, {cast_scale_name});
+                    auto* cast_scale_attr = cast_scale->add_attribute();
+                    cast_scale_attr->set_name("to");
+                    cast_scale_attr->set_type(onnx::AttributeProto_AttributeType_INT);
+                    cast_scale_attr->set_i(*quantize_arithmetic_type);
+                    lowered_scale_name = cast_scale_name;
+                }
+
+                if (zero_point_tensor != nullptr)
+                {
+                    if (NeedsPromotedZeroPoint(zero_point_tensor->data_type()))
+                    {
+                        lowered_zero_name = MakeLoweredName(node_base, "zero_promoted", ++unique_id);
+                        if (AddPromotedIntegerInitializer(graph, index, lowered_zero_name, *zero_point_tensor,
+                                                          GetPromotedZeroPointType(zero_point_tensor->data_type(),
+                                                                                   *quantize_arithmetic_type)) == nullptr)
+                        {
+                            *lowered_nodes.Add() = node;
+                            continue;
+                        }
+                    }
+                    if (!MaybeAddAxisReshape(graph, index, lowered_nodes, node, lowered_zero_name,
+                                             MakeLoweredName(node_base, "zero", ++unique_id), index.FindTensorRank(node.input(0)),
+                                             axis_attr, *index.FindInitializer(lowered_zero_name), block_size, unique_id, lowered_zero_name))
+                    {
+                        *lowered_nodes.Add() = node;
+                        continue;
+                    }
+                }
+
+                const std::string cast_input_name = MakeLoweredName(node_base, "input_cast", ++unique_id);
+                auto* cast_input =
+                    AppendNode(lowered_nodes, node, "Cast", MakeLoweredName(node_base, "cast_input", unique_id),
+                               {node.input(0)}, {cast_input_name});
+                auto* cast_input_attr = cast_input->add_attribute();
+                cast_input_attr->set_name("to");
+                cast_input_attr->set_type(onnx::AttributeProto_AttributeType_INT);
+                cast_input_attr->set_i(*quantize_arithmetic_type);
+
+                const std::string div_name = MakeLoweredName(node_base, "div", ++unique_id);
+                AppendNode(lowered_nodes, node, "Div", MakeLoweredName(node_base, "div_node", unique_id),
+                           {cast_input_name, lowered_scale_name}, {div_name});
+
+                std::string shifted_name = div_name;
+                if (!lowered_zero_name.empty())
+                {
+                    const std::string cast_zero_name = MakeLoweredName(node_base, "zero_cast", ++unique_id);
+                    auto* cast_zero =
+                        AppendNode(lowered_nodes, node, "Cast", MakeLoweredName(node_base, "cast_zero", unique_id),
+                                   {lowered_zero_name}, {cast_zero_name});
+                    auto* cast_zero_attr = cast_zero->add_attribute();
+                    cast_zero_attr->set_name("to");
+                    cast_zero_attr->set_type(onnx::AttributeProto_AttributeType_INT);
+                    cast_zero_attr->set_i(*quantize_arithmetic_type);
+
+                    shifted_name = MakeLoweredName(node_base, "shifted", ++unique_id);
+                    AppendNode(lowered_nodes, node, "Add", MakeLoweredName(node_base, "add", unique_id),
+                               {div_name, cast_zero_name}, {shifted_name});
+                }
+
+                const std::string rounded_name = MakeLoweredName(node_base, "rounded", ++unique_id);
+                AppendNode(lowered_nodes, node, "Round", MakeLoweredName(node_base, "round", unique_id),
+                           {shifted_name}, {rounded_name});
+
+                const int32_t qrange_constant_type =
+                    output_type == onnx::TensorProto_DataType_UINT32 ? onnx::TensorProto_DataType_INT64
+                                                                     : onnx::TensorProto_DataType_INT32;
+                const std::string qmin_name = MakeLoweredName(node_base, "qmin", ++unique_id);
+                const std::string qmax_name = MakeLoweredName(node_base, "qmax", ++unique_id);
+                AddScalarInitializer(graph, index, qmin_name, qrange_constant_type, qmin);
+                AddScalarInitializer(graph, index, qmax_name, qrange_constant_type, qmax);
+
+                const std::string qmin_cast_name = MakeLoweredName(node_base, "qmin_cast", ++unique_id);
+                const std::string qmax_cast_name = MakeLoweredName(node_base, "qmax_cast", ++unique_id);
+                auto* qmin_cast =
+                    AppendNode(lowered_nodes, node, "Cast", MakeLoweredName(node_base, "cast_qmin", unique_id),
+                               {qmin_name}, {qmin_cast_name});
+                auto* qmin_cast_attr = qmin_cast->add_attribute();
+                qmin_cast_attr->set_name("to");
+                qmin_cast_attr->set_type(onnx::AttributeProto_AttributeType_INT);
+                qmin_cast_attr->set_i(*quantize_arithmetic_type);
+
+                auto* qmax_cast =
+                    AppendNode(lowered_nodes, node, "Cast", MakeLoweredName(node_base, "cast_qmax", ++unique_id),
+                               {qmax_name}, {qmax_cast_name});
+                auto* qmax_cast_attr = qmax_cast->add_attribute();
+                qmax_cast_attr->set_name("to");
+                qmax_cast_attr->set_type(onnx::AttributeProto_AttributeType_INT);
+                qmax_cast_attr->set_i(*quantize_arithmetic_type);
+
+                const std::string clamped_min_name = MakeLoweredName(node_base, "clamped_min", ++unique_id);
+                AppendNode(lowered_nodes, node, "Max", MakeLoweredName(node_base, "max", unique_id),
+                           {rounded_name, qmin_cast_name}, {clamped_min_name});
+                const std::string clamped_name = MakeLoweredName(node_base, "clamped", ++unique_id);
+                AppendNode(lowered_nodes, node, "Min", MakeLoweredName(node_base, "min", unique_id),
+                           {clamped_min_name, qmax_cast_name}, {clamped_name});
+
+                auto* final_cast =
+                    AppendNode(lowered_nodes, node, "Cast", MakeLoweredName(node_base, "cast_output", ++unique_id),
+                               {clamped_name}, {node.output(0)});
+                auto* final_cast_attr = final_cast->add_attribute();
+                final_cast_attr->set_name("to");
+                final_cast_attr->set_type(onnx::AttributeProto_AttributeType_INT);
+                final_cast_attr->set_i(output_type);
+
+                ++lowered_qdq_info.lowered_node_count;
+                continue;
+            }
+        }
+
+        // Fall-through: policy said "keep native" OR a dtype/shape corner
+        // case inside the rewrite declined. Either way, emit the original
+        // node unchanged so ownership is preserved.
+        *lowered_nodes.Add() = node;
+    }
+
+    // Invariant at this point: |lowered_nodes| >= |graph.node()|, every
+    // original ORT node has either a verbatim copy or a set of helpers
+    // sharing its doc_string, and any folded constant DQ has been logged
+    // in lowered_qdq_info for the provider's capability remap.
+    graph.mutable_node()->Swap(&lowered_nodes);
+    return lowered_qdq_info;
+}
+
+}  // namespace trt_rtx_ep

--- a/src/qdq_lowering.h
+++ b/src/qdq_lowering.h
@@ -1,0 +1,79 @@
+#pragma once
+
+// Policy-driven Q/DQ lowering for the TensorRT-RTX execution provider.
+//
+// The TRT-RTX ONNX parser accepts a *subset* of ONNX Q/DQ: it handles the
+// symmetric, low-bit patterns that its quantization-aware fuser is tuned for
+// (e.g. int8/uint8 Q/DQ around Gemm/MatMul/Conv/ConvTranspose with zp == 0),
+// but it does not accept:
+//   * asymmetric Q/DQ (zero_point != 0),
+//   * int32 / uint32 as DequantizeLinear input types.
+//
+// In addition, this module deliberately avoids lowering some otherwise-valid
+// ONNX Q/DQ patterns when doing so would be numerically unsafe (for example,
+// QuantizeLinear to int16/uint16 with fp16/bf16 scales, or QuantizeLinear to
+// int32/uint32 where a floating rewrite cannot represent the full integer
+// range exactly).
+//
+// Rather than lose an entire subgraph or silently miscompile, this module
+// rewrites *only* those non-native Q/DQ patterns into equivalent ONNX
+// arithmetic before the proto is handed to TRT, while leaving the native-
+// friendly patterns completely untouched so TRT can still apply its fusions.
+//
+// The rewrite is run twice with identical inputs:
+//   1. During capability discovery (GetSupportedList), so the set of nodes
+//      we claim must match what TRT will actually parse.
+//   2. During engine build (CreateNodeComputeInfoFromGraph), so TRT builds
+//      against the same graph we advertised support for.
+//
+// Both call sites MUST call RunQdqLoweringForTensorRt on the serialized
+// proto. Any drift between the two (e.g. policy change that only runs on
+// one side) would cause TRT to refuse nodes that ORT already partitioned
+// to this EP.
+
+#include "onnx/onnx_pb.h"
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace trt_rtx_ep
+{
+
+// One folded DequantizeLinear record.
+//
+// Constant DQ is folded to a float initializer + trivial Identity. When TRT
+// later prunes that Identity, the parser's supported-node list can lose the
+// mapping back to the original ORT node id. The provider uses this struct to
+// reattach the original ORT node to any parser subgraph that still references
+// `output_name`, so ORT partition ownership matches the pre-lowered graph.
+struct FoldedQdqNodeInfo
+{
+    size_t original_node_id = 0;
+    std::string output_name;
+};
+
+// Summary of what lowering did to the proto.
+//
+//   lowered_node_count     : number of Q/DQ nodes that were rewritten or
+//                            folded (diagnostic counter, not load-bearing).
+//   folded_constant_nodes  : must be replayed by the provider during the
+//                            proto -> ORT node remap (see comments above).
+struct LoweredQdqInfo
+{
+    size_t lowered_node_count = 0;
+    std::vector<FoldedQdqNodeInfo> folded_constant_nodes;
+};
+
+// Rewrites Q/DQ nodes in `model_proto` in-place according to the policy
+// described at the top of this header. Non-Q/DQ nodes, and Q/DQ nodes that
+// fall outside the lowering policy, are left byte-for-byte unchanged so they
+// continue to go through TRT's native Q/DQ path.
+//
+// Preconditions: initializer payloads may be inline (raw_data / typed fields)
+// or external with location == "_MEM_ADDR_" and offset == reinterpret_cast<
+// int64_t>(raw_ptr) -- the convention produced by OrtGraphToProto's custom
+// initializer handler in the provider.
+LoweredQdqInfo RunQdqLoweringForTensorRt(onnx::ModelProto& model_proto);
+
+}  // namespace trt_rtx_ep

--- a/src/tensorrt_rtx_execution_provider.cc
+++ b/src/tensorrt_rtx_execution_provider.cc
@@ -16,10 +16,12 @@
 #include "tensorrt_rtx_execution_provider.h"
 
 #include "onnx_ctx_model_helper.h"
+#include "proto_node_id_utils.h"
 #include "tensorrt_rtx_allocator.h"
 #include "tensorrt_rtx_execution_provider_stream_support.h"
 #include "tensorrt_rtx_provider_factory.h"
 #include "tensorrt_rtx_provider_options.h"
+#include "trt_proto_preprocessing.h"
 
 #include "utils/cuda/cuda_call.h"
 #include "utils/ep_utils.h"
@@ -38,15 +40,15 @@
 #include <algorithm>
 #include <chrono>
 #include <cstring>
-#include <filesystem>
-#include <fstream>
 #include <functional>
 #include <iostream>
 #include <list>
-#include <thread>
+#include <limits>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <sstream>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #ifdef _WIN32
@@ -101,9 +103,11 @@ int GetNumProfiles(std::unordered_map<std::string, std::vector<std::vector<int64
     return num_profile;
 }
 
-// Anonymous namespace for cycle detection helper
+// Anonymous namespace for local helpers used during graph serialization/remap.
 namespace
 {
+constexpr const char* kExternalMemAddrLocation = "_MEM_ADDR_";
+
 // Helper function to detect cycles in graph using DFS
 bool FindCycleHelper(size_t i, const std::list<size_t>* adjacency_map, bool visited[], bool* st,
                      std::vector<size_t>& cycles)
@@ -130,8 +134,8 @@ bool FindCycleHelper(size_t i, const std::list<size_t>* adjacency_map, bool visi
     return false;
 }
 
-// Helper function to create initializer data handler for OrtGraphToProto
-// Initializers are stored as external references with memory addresses
+// OrtGraphToProto stores initializer payloads as external references, so we
+// encode the original memory address in the TensorProto offset field.
 OrtEpUtils::HandleInitializerDataFunc CreateInitializerDataHandler()
 {
     return [](const OrtValueInfo* value_info, const void* data, size_t bytes, bool& is_external, std::string& location,
@@ -140,7 +144,7 @@ OrtEpUtils::HandleInitializerDataFunc CreateInitializerDataHandler()
         (void)value_info;
         (void)bytes;
         offset = reinterpret_cast<int64_t>(data);
-        location = "_MEM_ADDR_";  // Special location tag indicating offset is a memory pointer
+        location = kExternalMemAddrLocation;
         is_external = true;
         return Ort::Status{nullptr};
     };
@@ -513,9 +517,9 @@ SubGraphCollection_t TensorrtRtxExecutionProvider::GetSupportedList(SubGraphColl
             parent_id_to_index[parent_nodes[idx].GetId()] = idx;
         }
 
-        auto subgraph_nodes = subgraph_owner.GetNodes();
-        subgraph_parent_indices.reserve(subgraph_nodes.size());
-        for (const auto& node : subgraph_nodes)
+        auto subgraph_node_views = subgraph_owner.GetNodes();
+        subgraph_parent_indices.reserve(subgraph_node_views.size());
+        for (const auto& node : subgraph_node_views)
         {
             auto it = parent_id_to_index.find(node.GetId());
             if (it != parent_id_to_index.end())
@@ -528,6 +532,12 @@ SubGraphCollection_t TensorrtRtxExecutionProvider::GetSupportedList(SubGraphColl
         const OrtGraph& graph_to_serialize = *subgraph_owner;
         auto status = OrtEpUtils::OrtGraphToProto(graph_to_serialize, model_proto, handle_initializer_data);
         Ort::ThrowOnError(status);
+        // Capability discovery must see the same proto preprocessing sequence
+        // that engine build will later apply. Today that includes policy-driven
+        // Q/DQ lowering plus logical-output compatibility cleanup for
+        // Chromium's bool->uint8 bridge, Clip bound compatibility for WebNN
+        // clamp defaults, and dilated pooling compatibility lowering.
+        const auto lowered_qdq_info = RunTensorRtProtoPreprocessing(model_proto);
 
         // TRT parser consumes serialized model bytes.
         std::string string_buf;
@@ -568,32 +578,37 @@ SubGraphCollection_t TensorrtRtxExecutionProvider::GetSupportedList(SubGraphColl
             std::unique_ptr<nvinfer1::INetworkDefinition>(trt_builder->createNetworkV2(network_flags));
         bool is_model_supported = false;
 
-        // Build mapping from proto node index -> ORT node index using doc_string node ids.
-        auto build_proto_to_ort_index = [&model_proto](const Ort::ConstGraph& ort_subgraph_view) {
-            auto ort_nodes = ort_subgraph_view.GetNodes();
-            std::unordered_map<size_t, size_t> ort_node_id_to_index;
-            ort_node_id_to_index.reserve(ort_nodes.size());
-            for (size_t idx = 0; idx < ort_nodes.size(); ++idx)
-            {
-                ort_node_id_to_index[ort_nodes[idx].GetId()] = idx;
-            }
-
-            std::vector<size_t> proto_idx_to_ort_idx;
+        // Lowering can expand one original ORT node into several serialized ONNX nodes:
+        //
+        //   ORT node 2: QuantizeLinear
+        //        |
+        //        v
+        //   proto: Div(doc=2) -> Add(doc=2) -> Round(doc=2) -> Clamp(doc=2) -> Cast(doc=2)
+        //
+        // TRT reports support in terms of proto node indices, but ORT capability
+        // partitioning still needs the original ORT node index. We therefore read
+        // the original ORT node id back out of doc_string and map:
+        //
+        //   proto node index -> original ORT node id -> ORT node index
+        //
+        // Any proto node without a valid original ORT id is a lowering-only helper
+        // and must not claim ownership of an unrelated ORT node.
+        auto build_proto_to_ort_index = [&model_proto](const std::unordered_map<size_t, size_t>& ort_node_id_to_index) {
+            std::vector<std::optional<size_t>> proto_idx_to_ort_idx;
             const auto& graph_proto = model_proto.graph();
             proto_idx_to_ort_idx.reserve(graph_proto.node_size());
             for (int proto_idx = 0; proto_idx < graph_proto.node_size(); ++proto_idx)
             {
                 const auto& node_proto = graph_proto.node(proto_idx);
-                try
+                if (const auto node_id = TryParseNodeId(node_proto.doc_string()))
                 {
-                    size_t ort_node_id = std::stoull(node_proto.doc_string());
-                    auto it = ort_node_id_to_index.find(ort_node_id);
-                    proto_idx_to_ort_idx.push_back(
-                        (it != ort_node_id_to_index.end()) ? it->second : static_cast<size_t>(proto_idx));
+                    auto it = ort_node_id_to_index.find(*node_id);
+                    proto_idx_to_ort_idx.push_back((it != ort_node_id_to_index.end()) ? std::optional<size_t>(it->second)
+                                                                                       : std::nullopt);
                 }
-                catch (...)
+                else
                 {
-                    proto_idx_to_ort_idx.push_back(static_cast<size_t>(proto_idx));
+                    proto_idx_to_ort_idx.push_back(std::nullopt);
                 }
             }
 
@@ -613,29 +628,138 @@ SubGraphCollection_t TensorrtRtxExecutionProvider::GetSupportedList(SubGraphColl
 
             // Get ORT nodes from subgraph
             Ort::ConstGraph ort_subgraph_view{subgraph_view};
-            auto proto_idx_to_ort_idx = build_proto_to_ort_index(ort_subgraph_view);
-
-            // TRT returns subgraph nodes as indices into the serialized model graph.
-            // Convert those to ORT node indices for recursive processing.
-            // Note: Calling getNbSubgraphs or getSubgraphNodes before calling supportsModelV2 results in
-            // undefined behavior.
-            auto num_subgraphs = trt_parser->getNbSubgraphs();
-            parser_nodes_list.reserve(num_subgraphs);
-
-            for (int64_t i = 0; i < num_subgraphs; ++i)
+            auto ort_nodes = ort_subgraph_view.GetNodes();
+            std::unordered_map<size_t, size_t> ort_node_id_to_index;
+            ort_node_id_to_index.reserve(ort_nodes.size());
+            for (size_t idx = 0; idx < ort_nodes.size(); ++idx)
             {
-                int64_t subgraph_len = 0;
-                int64_t* subgraph_nodes = trt_parser->getSubgraphNodes(i, subgraph_len);
-                parser_nodes_list.emplace_back();
-                parser_nodes_list.back().first.reserve(subgraph_len);
-                for (int64_t j = 0; j < subgraph_len; ++j)
+                ort_node_id_to_index[ort_nodes[idx].GetId()] = idx;
+            }
+            auto proto_idx_to_ort_idx = build_proto_to_ort_index(ort_node_id_to_index);
+
+            // Only query subgraph info when parsing succeeded.
+            // Calling getNbSubgraphs()/getSubgraphNodes() on a failed parser
+            // crashes — leave parser_nodes_list empty so the recursion correctly
+            // treats this group as fully unsupported.
+            if (is_model_supported)
+            {
+                // TRT returns subgraph nodes as indices into the serialized model graph.
+                // Convert those to ORT node indices for recursive processing.
+                // Note: Calling getNbSubgraphs or getSubgraphNodes before calling supportsModelV2 results in
+                // undefined behavior.
+                auto num_subgraphs = trt_parser->getNbSubgraphs();
+                parser_nodes_list.reserve(num_subgraphs);
+
+                for (int64_t i = 0; i < num_subgraphs; ++i)
                 {
-                    // Map proto node index to ORT node index
-                    size_t proto_node_idx = static_cast<size_t>(subgraph_nodes[j]);
-                    size_t ort_node_idx = proto_idx_to_ort_idx[proto_node_idx];
-                    parser_nodes_list.back().first.push_back(static_cast<int64_t>(ort_node_idx));
+                    int64_t subgraph_len = 0;
+                    int64_t* subgraph_nodes = trt_parser->getSubgraphNodes(i, subgraph_len);
+                    parser_nodes_list.emplace_back();
+                    parser_nodes_list.back().first.reserve(subgraph_len);
+                    std::unordered_set<size_t> seen_ort_node_indices;
+                    for (int64_t j = 0; j < subgraph_len; ++j)
+                    {
+                        // Lowering can expand one ORT node into several proto nodes. We only
+                        // keep parser nodes that still carry a valid original ORT node id.
+                        size_t proto_node_idx = static_cast<size_t>(subgraph_nodes[j]);
+                        if (proto_node_idx >= proto_idx_to_ort_idx.size() || !proto_idx_to_ort_idx[proto_node_idx].has_value())
+                        {
+                            continue;
+                        }
+
+                        size_t ort_node_idx = *proto_idx_to_ort_idx[proto_node_idx];
+                        if (seen_ort_node_indices.insert(ort_node_idx).second)
+                        {
+                            parser_nodes_list.back().first.push_back(static_cast<int64_t>(ort_node_idx));
+                        }
+                    }
+                    parser_nodes_list.back().second = is_model_supported;
                 }
-                parser_nodes_list.back().second = is_model_supported;
+            }
+
+            if (!lowered_qdq_info.folded_constant_nodes.empty())
+            {
+                // Constant-folded DQ nodes can disappear from the parser's node list entirely.
+                // Reattach the original ORT node to every supported subgraph that still references
+                // the folded tensor so partition ownership matches the pre-lowered graph.
+                //
+                //   before lowering: dq_node --> consumer
+                //   after folding   : folded_initializer -- Identity? --> consumer
+                //
+                // If TRT prunes the helper Identity, the parser may only report the consumer.
+                // We recover ownership by looking for subgraphs that still mention the folded
+                // tensor name and then reattaching the original ORT DQ node to those subgraphs.
+                std::unordered_map<std::string, std::vector<size_t>> tensor_to_parser_subgraphs;
+                const auto& graph_proto = model_proto.graph();
+                for (size_t parser_idx = 0; parser_idx < parser_nodes_list.size(); ++parser_idx)
+                {
+                    for (const auto proto_node_index_i64 : parser_nodes_list[parser_idx].first)
+                    {
+                        const size_t ort_node_index = static_cast<size_t>(proto_node_index_i64);
+                        if (ort_node_index >= ort_nodes.size())
+                        {
+                            continue;
+                        }
+                        const auto ort_node_id = ort_nodes[ort_node_index].GetId();
+                        for (int proto_idx = 0; proto_idx < graph_proto.node_size(); ++proto_idx)
+                        {
+                            const auto& node_proto = graph_proto.node(proto_idx);
+                            const auto node_id = TryParseNodeId(node_proto.doc_string());
+                            if (!node_id || *node_id != ort_node_id)
+                            {
+                                continue;
+                            }
+                            for (const auto& input_name : node_proto.input())
+                            {
+                                if (!input_name.empty())
+                                {
+                                    tensor_to_parser_subgraphs[input_name].push_back(parser_idx);
+                                }
+                            }
+                            for (const auto& output_name : node_proto.output())
+                            {
+                                if (!output_name.empty())
+                                {
+                                    tensor_to_parser_subgraphs[output_name].push_back(parser_idx);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                std::vector<std::unordered_set<size_t>> seen_ort_node_indices(parser_nodes_list.size());
+                for (size_t parser_idx = 0; parser_idx < parser_nodes_list.size(); ++parser_idx)
+                {
+                    seen_ort_node_indices[parser_idx].insert(parser_nodes_list[parser_idx].first.begin(),
+                                                             parser_nodes_list[parser_idx].first.end());
+                }
+
+                for (const auto& folded_node : lowered_qdq_info.folded_constant_nodes)
+                {
+                    auto ort_it = ort_node_id_to_index.find(folded_node.original_node_id);
+                    if (ort_it == ort_node_id_to_index.end())
+                    {
+                        continue;
+                    }
+
+                    auto subgraph_it = tensor_to_parser_subgraphs.find(folded_node.output_name);
+                    if (subgraph_it == tensor_to_parser_subgraphs.end())
+                    {
+                        continue;
+                    }
+
+                    for (const size_t parser_idx : subgraph_it->second)
+                    {
+                        if (parser_idx >= parser_nodes_list.size())
+                        {
+                            continue;
+                        }
+                        if (seen_ort_node_indices[parser_idx].insert(ort_it->second).second)
+                        {
+                            parser_nodes_list[parser_idx].first.push_back(static_cast<int64_t>(ort_it->second));
+                        }
+                    }
+                }
             }
         }
 
@@ -675,8 +799,10 @@ static bool CheckNodeDataTypes(const Ort::ConstNode& node)
 
         if (input_ptr != nullptr)
         {
-
             auto type_info = input.TypeInfo();
+            if (!type_info || type_info.GetONNXType() != ONNX_TYPE_TENSOR)
+                continue;  // skip unconnected or non-tensor inputs
+
             if (!IsSupportedDataType(type_info.GetTensorTypeAndShapeInfo().GetElementType()))
             {
                 return false;
@@ -686,7 +812,17 @@ static bool CheckNodeDataTypes(const Ort::ConstNode& node)
     // Check output data types
     for (auto output : node.GetOutputs())
     {
+        const OrtValueInfo* output_ptr = (const OrtValueInfo*)(output);
+        if (output_ptr == nullptr)
+            continue;  // optional unconnected output (e.g., LSTM Y sequence output)
+
         auto type_info = output.TypeInfo();
+        if (!type_info)
+            continue;  // no type info for unconnected optional output
+
+        if (type_info.GetONNXType() != ONNX_TYPE_TENSOR)
+            continue;  // non-tensor outputs (sequence, map, etc.) are not type-checked here
+
         if (!IsSupportedDataType(type_info.GetTensorTypeAndShapeInfo().GetElementType()))
         {
             return false;
@@ -947,10 +1083,14 @@ OrtStatus* TensorrtRtxExecutionProvider::CreateNodeComputeInfoFromGraph(
     auto handle_initializer_data = CreateInitializerDataHandler();
 
     OrtEpUtils::OrtGraphToProto(*graph, model_proto, handle_initializer_data);
+    // Engine build must replay the same preprocessing sequence as
+    // GetSupportedList so TRT compiles the exact proto whose support we
+    // advertised during partitioning.
+    (void)RunTensorRtProtoPreprocessing(model_proto);
     std::string string_buf;
     model_proto.SerializeToString(&string_buf);
 
-    if ( dump_subgraphs_)
+    if (dump_subgraphs_)
     {
         // Dump TensorRT subgraphs
         const char* name = nullptr;
@@ -1598,19 +1738,37 @@ bool TensorrtRtxExecutionProvider::DetectTensorRTGraphCycles(SubGraphCollection_
                 // Process inputs
                 for (auto input : node.GetInputs())
                 {
-                    input_to_nodes_map[input.GetName()].insert(node_name);
+                    const OrtValueInfo* in_ptr = (const OrtValueInfo*)(input);
+                    if (in_ptr == nullptr)
+                        continue;  // optional unconnected input
+                    std::string in_name = input.GetName();
+                    if (in_name.empty())
+                        continue;
+                    input_to_nodes_map[in_name].insert(node_name);
                 }
 
                 // Process implicit inputs
                 for (auto input : node.GetImplicitInputs())
                 {
-                    input_to_nodes_map[input.GetName()].insert(node_name);
+                    const OrtValueInfo* in_ptr = (const OrtValueInfo*)(input);
+                    if (in_ptr == nullptr)
+                        continue;  // optional unconnected implicit input
+                    std::string in_name = input.GetName();
+                    if (in_name.empty())
+                        continue;
+                    input_to_nodes_map[in_name].insert(node_name);
                 }
 
                 // Process outputs
                 for (auto output : node.GetOutputs())
                 {
-                    node_to_outputs_map[node_name].insert(output.GetName());
+                    const OrtValueInfo* out_ptr = (const OrtValueInfo*)(output);
+                    if (out_ptr == nullptr)
+                        continue;  // optional unconnected output (e.g., GRU/LSTM Y sequence output)
+                    std::string out_name = output.GetName();
+                    if (out_name.empty())
+                        continue;
+                    node_to_outputs_map[node_name].insert(out_name);
                 }
             }
         }
@@ -2015,16 +2173,12 @@ TensorrtRtxExecutionProvider::TensorrtRtxExecutionProvider(TensorrtRtxExecutionP
         min_subgraph_size_ = 1;
     }
 
-    // If ep_context_file_path_ is provided as a directory, create it if it's not existed
-    if (dump_ep_context_model_ && !ep_context_file_path_.empty() &&
-        std::filesystem::path(ep_context_file_path_).extension().empty() &&
-        !std::filesystem::is_directory(ep_context_file_path_))
-    {
-        if (!std::filesystem::create_directory(ep_context_file_path_))
-        {
-            throw std::runtime_error("Failed to create directory " + ep_context_file_path_);
-        }
-    }
+    // Note: Previously this block auto-created a directory when ep_context_file_path_
+    // had no extension. That was wrong: SetEpContextBinaryInformation(dir, stem) produces
+    // ep_context_file_path_ = "dir/stem" (no extension), which is a file stem, not a
+    // directory. Creating it as a directory caused the engine cache to be placed in a
+    // stem-named subfolder instead of the requested dir. Directory semantics are now
+    // expressed only via trailing separator (handled in GetPathOrParentPathOfCtxModel).
 
     // If dump_ep_context_model_ is enabled, TRT EP forces cache_path_ to be the relative path of ep_context_file_path_.
     // For example,
@@ -2358,8 +2512,15 @@ OrtStatus* ORT_API_CALL TensorrtRtxExecutionProvider::GetCapabilityImpl(
         {
             // Only claim EPContext nodes that belong to this EP.
             // If the "source" attribute is present and doesn't match our EP name, skip the node.
+            //
+            // NOTE: The Ort C++ wrapper for Node_GetAttributeByName returns IsOK()==true
+            // for attributes that are NOT present on the node, leaving `source_attr` as a
+            // null OrtOpAttr*. Calling GetType() on that null pointer causes an access
+            // violation. Guard with an explicit validity check to support backward
+            // compatibility with legacy EPContext models that don't set a "source" attribute.
             Ort::ConstOpAttr source_attr;
             if (node.GetAttributeByName(SOURCE.c_str(), source_attr).IsOK() &&
+                static_cast<const OrtOpAttr*>(source_attr) != nullptr &&
                 source_attr.GetType() == OrtOpAttrType::ORT_OP_ATTR_STRING)
             {
                 std::string source_value;

--- a/src/tensorrt_rtx_execution_provider.h
+++ b/src/tensorrt_rtx_execution_provider.h
@@ -55,6 +55,13 @@ using trt_rtx_ep::kCudaGraphAnnotationSkip;
 namespace trt_rtx_ep
 {
 
+// SubGraph_t and SubGraphCollection_t were removed from NvOnnxParser.h between
+// TRT-RTX 1.5.0.97 and 1.5.0.99. Define them here for those builds and all 1.6.x+.
+#if TRT_MAJOR_RTX >= 2 || TRT_MINOR_RTX >= 6 || (TRT_MINOR_RTX == 5 && TRT_BUILD_RTX >= 99)
+using SubGraph_t = std::pair<std::vector<size_t>, bool>;
+using SubGraphCollection_t = std::vector<SubGraph_t>;
+#endif
+
 constexpr size_t kTensorRTEngineHeaderSize = 64;
 
 // Helper functions for engine header validation

--- a/src/tensorrt_rtx_execution_provider_info.cc
+++ b/src/tensorrt_rtx_execution_provider_info.cc
@@ -69,6 +69,7 @@ TensorrtRtxExecutionProviderInfo TensorrtRtxExecutionProviderInfo::FromProviderO
             .AddAssignmentToReference(onnxruntime::tensorrt_rtx::provider_option_names::kUseExternalDataInitializer, info.use_external_data_initializer)
             .AddAssignmentToReference(onnxruntime::tensorrt_rtx::provider_option_names::kMultiProfileEnable, info.multi_profile_enable)
             .AddAssignmentToReference(onnxruntime::tensorrt_rtx::provider_option_names::kRuntimeCacheFile, info.runtime_cache_path)
+            .AddAssignmentToReference(onnxruntime::tensorrt_rtx::provider_option_names::kOpTypesToExclude, info.op_types_to_exclude)
             .AddAssignmentToReference(kOrtSessionOptionEpContextEnable, info.dump_ep_context_model)
             .AddAssignmentToReference(kOrtSessionOptionEpContextFilePath, info.ep_context_file_path)
             .AddAssignmentToReference(kOrtSessionOptionEpContextEmbedMode, info.ep_context_embed_mode)

--- a/src/tensorrt_rtx_execution_provider_utils.h
+++ b/src/tensorrt_rtx_execution_provider_utils.h
@@ -326,6 +326,9 @@ inline HashValue TRTGenerateId(const OrtGraph* graph, const std::string& trt_ver
     {
         for (auto output : node.GetOutputs())
         {
+            const OrtValueInfo* out_ptr = (const OrtValueInfo*)(output);
+            if (out_ptr == nullptr)
+                continue;  // skip unconnected optional outputs (e.g., LSTM Y sequence output)
             hash_str(output.GetName());
         }
     }

--- a/src/tensorrt_rtx_provider_options.h
+++ b/src/tensorrt_rtx_provider_options.h
@@ -34,6 +34,8 @@
 //! - `kMultiProfileEnable`: Enables or disables multi-profile support.
 //! - `kUseExternalDataInitializer`: Enables or disables use of external data initializers.
 //! - `kRuntimeCacheFile`: Specifies the path to the runtime cache file.
+//! - `kOpTypesToExclude`: Specifies a comma-separated list of op types that the
+//!   TRT RTX EP should leave to other EPs during partitioning.
 //!
 //! \namespace onnxruntime::tensorrt_rtx::run_option_names
 //! \brief Contains run option name constants for TensorRT RTX EP runtime configuration.
@@ -62,6 +64,7 @@ constexpr const char* kCudaGraphEnable = "enable_cuda_graph";
 constexpr const char* kMultiProfileEnable = "nv_multi_profile_enable";
 constexpr const char* kUseExternalDataInitializer = "nv_use_external_data_initializer";
 constexpr const char* kRuntimeCacheFile = "nv_runtime_cache_path";
+constexpr const char* kOpTypesToExclude = "nv_op_types_to_exclude";
 
 }  // namespace provider_option_names
 

--- a/src/trt_proto_preprocessing.cc
+++ b/src/trt_proto_preprocessing.cc
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "trt_proto_preprocessing.h"
+
+#include "clip_bound_compatibility.h"
+#include "logical_output_compatibility.h"
+#include "pooling_dilation_compatibility.h"
+
+namespace trt_rtx_ep
+{
+
+LoweredQdqInfo RunTensorRtProtoPreprocessing(onnx::ModelProto& model_proto)
+{
+    auto lowered_qdq_info = RunQdqLoweringForTensorRt(model_proto);
+
+    // Run logical-output cleanup after Q/DQ lowering so the final proto handed
+    // to TRT never contains Chromium's redundant bool -> uint8 bridge when it
+    // can be canonicalized safely to an int32 bridge.
+    RunLogicalOutputCompatibilityForTensorRt(model_proto);
+
+    // Canonicalize WebNN's unbounded clamp defaults before TRT parses Clip
+    // bounds as finite activation parameters.
+    RunClipBoundCompatibilityForTensorRt(model_proto);
+
+    // Lower provably-equivalent dilated AveragePool/MaxPool cases into
+    // primitive ops so TRT does not see unsupported pooling dilations.
+    RunPoolingDilationCompatibilityForTensorRt(model_proto);
+    return lowered_qdq_info;
+}
+
+}  // namespace trt_rtx_ep

--- a/src/trt_proto_preprocessing.h
+++ b/src/trt_proto_preprocessing.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "qdq_lowering.h"
+
+namespace trt_rtx_ep
+{
+
+// Runs every graph rewrite the EP needs before handing the serialized ONNX
+// proto to TRT-RTX.
+//
+// This wrapper keeps provider call sites honest: capability discovery and
+// engine build should both see the same rewritten proto, even as we add
+// compatibility passes that are orthogonal to Q/DQ lowering.
+//
+// Current stages:
+//   1. Policy-driven Q/DQ lowering / folding.
+//   2. Logical-output compatibility cleanup for Chromium's bool->uint8 bridge.
+//   3. Clip bound compatibility for WebNN clamp defaults represented as
+//      -inf/+inf.
+//   4. Pooling dilation compatibility for static, zero-padding AveragePool /
+//      MaxPool cases TRT-RTX rejects natively.
+LoweredQdqInfo RunTensorRtProtoPreprocessing(onnx::ModelProto& model_proto);
+
+}  // namespace trt_rtx_ep

--- a/src/utils/ort_graph_to_proto.h
+++ b/src/utils/ort_graph_to_proto.h
@@ -348,6 +348,7 @@ static Ort::Status KahnsTopologicalSort(
     }
 
     for (auto output : current.GetOutputs()) {
+      if (output == nullptr || output.GetName().empty()) continue;  // unconnected optional output
       auto consumer_infos = output.GetConsumers();
       for (auto consumer_info : consumer_infos) {
         const Ort::ConstNode consumer = consumer_info.node;
@@ -499,11 +500,13 @@ Ort::Status OrtGraphToProto(const OrtGraph& graph,
       // Handle node inputs
       std::vector<Ort::ConstValueInfo> ort_inputs = ort_node.GetInputs();
       for (const auto& vi : ort_inputs) {
-        if (vi == nullptr) {
-          // missing optional input.
+        if (vi == nullptr || vi.GetName().empty()) {
+          // missing or unconnected optional input.
           node_proto->add_input("");
           continue;
         }
+
+        std::string vi_name = vi.GetName();
 
         std::optional<std::string> value_name;
         value_name.emplace();
@@ -522,11 +525,15 @@ Ort::Status OrtGraphToProto(const OrtGraph& graph,
       // Handle node outputs
       std::vector<Ort::ConstValueInfo> ort_outputs = ort_node.GetOutputs();
       for (const auto& vi : ort_outputs) {
-        if (vi == nullptr) {
-          // missing optional output.
+        if (vi == nullptr || vi.GetName().empty()) {
+          // missing or unconnected optional output (e.g., LSTM Y sequence output when
+          // returnSequence=false). Calling ORT graph query APIs on such outputs can
+          // dereference null inside onnxruntime.dll and crash the GPU process.
           node_proto->add_output("");
           continue;
         }
+
+        std::string vi_name = vi.GetName();
 
         std::optional<std::string> value_name;
         value_name.emplace();
@@ -669,6 +676,13 @@ static Ort::Status GetOrtValueInfoTensorTypeShape(Ort::ConstValueInfo vi,
                                                   /*out*/ bool& has_shape) {
   try {
     Ort::ConstTypeInfo ort_type_info = vi.TypeInfo();
+    if (!ort_type_info) {
+      // Optional output with no type info (e.g., unconnected LSTM sequence output Y).
+      // Return with undefined element type and no shape — TRT will treat it as unsupported.
+      has_shape = false;
+      elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+      return Ort::Status{nullptr};
+    }
     ONNXType ort_onnx_type = ort_type_info.GetONNXType();
     ORT_EP_UTILS_C_RETURN_IF(ort_onnx_type != ONNX_TYPE_TENSOR, "Expected OrtValueInfo to represent a Tensor");
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# Google Test
+# =============================================================================
+include(FetchContent)
+# Prevent gtest from overriding compiler/CRT settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        v1.17.0
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(googletest)
+include(GoogleTest)
+
+# =============================================================================
+# Helper: copy a file into the test binary output directory.
+# Handles multi-config generators (e.g. Visual Studio) by copying into every
+# per-configuration subdirectory so the test executable always finds its DLLs.
+# =============================================================================
+macro(copy_to_test_bin file)
+    get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(_is_multi_config)
+        foreach(_config IN LISTS CMAKE_CONFIGURATION_TYPES)
+            file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${_config}")
+            file(COPY "${file}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/${_config}"
+                 FOLLOW_SYMLINK_CHAIN)
+        endforeach()
+    else()
+        file(COPY "${file}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
+             FOLLOW_SYMLINK_CHAIN)
+    endif()
+endmacro()
+
+# =============================================================================
+# Copy ORT runtime binaries into the test binary directory so the test
+# executable loads the same ORT build it was compiled against.
+# =============================================================================
+if(WIN32)
+    find_file(ORT_RUNTIME_DLL
+        onnxruntime.dll
+        HINTS ${ONNXRUNTIME_LIB_DIR}
+        REQUIRED)
+    find_file(ORT_PROVIDERS_SHARED_DLL
+        onnxruntime_providers_shared.dll
+        HINTS ${ONNXRUNTIME_LIB_DIR}
+        REQUIRED)
+    copy_to_test_bin("${ORT_RUNTIME_DLL}")
+    copy_to_test_bin("${ORT_PROVIDERS_SHARED_DLL}")
+else()
+    find_library(ORT_PROVIDERS_SHARED_LIB
+        onnxruntime_providers_shared
+        HINTS ${ONNXRUNTIME_LIB_DIR}
+        REQUIRED)
+    copy_to_test_bin("${ONNXRUNTIME_LIB}")
+    copy_to_test_bin("${ORT_PROVIDERS_SHARED_LIB}")
+endif()
+
+# =============================================================================
+# Copy TensorRT RTX binaries into the test binary directory.
+# =============================================================================
+if(WIN32)
+    find_file(TRT_RTX_DLL
+        NAMES ${TRT_RTX_DLL_NAME}
+        HINTS ${TRT_RTX_ROOT} ${TRT_RTX_LIB_DIR} "${TRT_RTX_ROOT}/bin" "${TRT_RTX_ROOT}/../bin"
+        REQUIRED)
+    find_file(TRT_ONNX_PARSER_DLL
+        NAMES ${TRT_ONNX_PARSER_DLL_NAME}
+        HINTS ${TRT_RTX_ROOT} ${TRT_RTX_LIB_DIR} "${TRT_RTX_ROOT}/bin" "${TRT_RTX_ROOT}/../bin"
+        REQUIRED)
+    copy_to_test_bin("${TRT_RTX_DLL}")
+    copy_to_test_bin("${TRT_ONNX_PARSER_DLL}")
+else()
+    copy_to_test_bin("${TRT_RTX_LIB}")
+    copy_to_test_bin("${TRT_ONNX_PARSER_LIB}")
+endif()
+
+# =============================================================================
+# Copy CUDA runtime into the test binary directory.
+# =============================================================================
+if(WIN32)
+    get_target_property(_cudart_loc CUDA::cudart IMPORTED_LOCATION_RELEASE)
+    if(NOT _cudart_loc)
+        get_target_property(_cudart_loc CUDA::cudart IMPORTED_LOCATION)
+    endif()
+    if(_cudart_loc)
+        get_filename_component(_cudart_dir "${_cudart_loc}" DIRECTORY)
+        get_filename_component(_cudart_name "${_cudart_loc}" NAME_WE)
+        find_file(CUDART_DLL
+            NAMES "${_cudart_name}.dll" "cudart64_${CUDAToolkit_VERSION_MAJOR}.dll" "cudart64_12.dll" "cudart64.dll"
+            HINTS "${CUDAToolkit_BIN_DIR}" "${_cudart_dir}" "${_cudart_dir}/../bin"
+            REQUIRED)
+        copy_to_test_bin("${CUDART_DLL}")
+    endif()
+else()
+    get_target_property(_cudart_loc CUDA::cudart IMPORTED_LOCATION_RELEASE)
+    if(NOT _cudart_loc)
+        get_target_property(_cudart_loc CUDA::cudart IMPORTED_LOCATION)
+    endif()
+    if(_cudart_loc)
+        copy_to_test_bin("${_cudart_loc}")
+    endif()
+endif()
+
+# =============================================================================
+# Model download
+# =============================================================================
+set(RESNET18_MODEL_NAME "resnet18_Opset18_timm.onnx")
+set(RESNET18_MODEL_URL
+    "https://huggingface.co/onnxmodelzoo/resnet18_Opset18_timm/resolve/main/resnet18_Opset18_timm.onnx")
+set(RESNET18_MODEL_PATH "${CMAKE_CURRENT_BINARY_DIR}/${RESNET18_MODEL_NAME}")
+
+if(NOT EXISTS "${RESNET18_MODEL_PATH}")
+    message(STATUS "Downloading ${RESNET18_MODEL_NAME} ...")
+    file(DOWNLOAD "${RESNET18_MODEL_URL}" "${RESNET18_MODEL_PATH}"
+         STATUS _dl_status
+         SHOW_PROGRESS)
+    list(GET _dl_status 0 _dl_code)
+    if(NOT _dl_code EQUAL 0)
+        message(WARNING "Failed to download ${RESNET18_MODEL_NAME} (${_dl_status}). "
+                        "test_load_model will fail at runtime.")
+        file(REMOVE "${RESNET18_MODEL_PATH}")
+    endif()
+endif()
+
+# =============================================================================
+# unittests
+# =============================================================================
+file(GLOB UNITTEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+set(PROTO_PREPROCESSING_TEST_SOURCES
+    "${CMAKE_SOURCE_DIR}/src/clip_bound_compatibility.cc"
+    "${CMAKE_SOURCE_DIR}/src/logical_output_compatibility.cc"
+    "${CMAKE_SOURCE_DIR}/src/pooling_dilation_compatibility.cc"
+    "${CMAKE_SOURCE_DIR}/src/qdq_lowering.cc"
+    "${CMAKE_SOURCE_DIR}/src/trt_proto_preprocessing.cc"
+)
+
+add_executable(unittests ${UNITTEST_SOURCES} ${PROTO_PREPROCESSING_TEST_SOURCES})
+
+set_target_properties(unittests PROPERTIES
+    CXX_STANDARD 17
+    CXX_EXTENSIONS OFF
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
+target_include_directories(unittests PRIVATE
+    ${ONNXRUNTIME_INCLUDE_DIR}
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/utils
+    ${CMAKE_SOURCE_DIR}
+)
+
+if(USE_VCPKG MATCHES "OFF")
+    target_include_directories(unittests PRIVATE
+        "${DEPS_PATH}/onnx-src"
+        "${DEPS_PATH}/onnx-build"
+        "${DEPS_PATH}/protobuf-src/src"
+        "${DEPS_PATH}/abseil-src"
+    )
+endif()
+
+# GTest::gtest (not gtest_main) — test_main.cpp provides main()
+target_link_libraries(unittests PRIVATE
+    ${ONNXRUNTIME_LIB}
+    GTest::gtest
+    CUDA::cudart
+    CUDA::cuda_driver
+    protobuf::libprotobuf
+    onnx
+)
+
+target_compile_definitions(unittests PRIVATE
+    ONNX_NAMESPACE=onnx
+    ONNX_ML
+    MODEL_FILE="${RESNET18_MODEL_PATH}"
+    EP_LIB_PATH="$<TARGET_FILE:TensorRTRtxEp>"
+)
+
+# Copy the built EP DLL next to the test executable after each build
+add_custom_command(TARGET unittests POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        $<TARGET_FILE:TensorRTRtxEp>
+        $<TARGET_FILE_DIR:unittests>
+    COMMENT "Copying TRT RTX EP DLL to test directory"
+)
+
+# Registers each TEST()/TEST_F() as a separate CTest test case
+gtest_discover_tests(unittests)

--- a/tests/test_tensorrt_rtx_basic.cpp
+++ b/tests/test_tensorrt_rtx_basic.cpp
@@ -1,0 +1,568 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ported from onnxruntime/test/providers/nv_tensorrt_rtx/nv_basic_test.cc
+// Uses only public ORT SDK APIs.
+
+#include <gtest/gtest.h>
+#include <onnxruntime_cxx_api.h>
+#include <onnxruntime_session_options_config_keys.h>
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <random>
+#include <string>
+#include <thread>
+
+#include "test_tensorrt_rtx_model_builder.h"
+#include "test_tensorrt_rtx_utils.h"
+
+extern std::unique_ptr<Ort::Env> ort_env;
+extern std::filesystem::path g_ep_lib_path;
+
+// Returns true if a CUDA device of SM >= 12.0 (Blackwell+) is present.
+// Returns false if CUDA is unavailable or the device is below SM 12.0.
+static bool IsBlackwellOrAbove() {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        return false;
+    }
+    int device_id = 0;
+    if (cudaGetDevice(&device_id) != cudaSuccess) {
+        return false;
+    }
+    cudaDeviceProp prop{};
+    if (cudaGetDeviceProperties(&prop, device_id) != cudaSuccess) {
+        return false;
+    }
+    const int cuda_arch = prop.major * 100 + prop.minor * 10;
+    return cuda_arch >= 1200;  // SM 12.0 = Blackwell
+}
+
+// Helper: append TRT RTX EP to session options using the global registration.
+static void AppendTrtRtxEp(
+    Ort::SessionOptions& so,
+    const std::unordered_map<std::string, std::string>& options = {}) {
+    auto devices = get_trt_rtx_devices(*ort_env);
+    ASSERT_FALSE(devices.empty()) << "No TRT RTX EP devices found.";
+    Ort::KeyValuePairs kv_options;
+    for (auto& [k, v] : options) {
+        kv_options.Add(k.c_str(), v.c_str());
+    }
+    so.AppendExecutionProvider_V2(*ort_env, devices, kv_options);
+}
+
+// =============================================================================
+// Context embed and reload tests
+// =============================================================================
+
+TEST(TensorRTRTXEpTest, ContextEmbedAndReload) {
+    const std::string model_name = "nv_execution_provider_test.onnx";
+    const std::string model_name_ctx = "nv_execution_provider_test_ctx.onnx";
+    clearFileIfExists(model_name_ctx);
+
+    model_builder::CreateBaseModel(model_name, "test", {1, 3, 2});
+
+    // AOT: compile and embed EP context
+    {
+        auto start = std::chrono::high_resolution_clock::now();
+        Ort::SessionOptions so;
+        so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+        so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, model_name_ctx.c_str());
+        AppendTrtRtxEp(so);
+        Ort::Session session(*ort_env, toOrtString(model_name).c_str(), so);
+        auto stop = std::chrono::high_resolution_clock::now();
+        std::cout << "Session creation AOT: "
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(stop - start).count()
+                  << " ms\n";
+
+        auto io_binding = generate_io_binding(session);
+        Ort::RunOptions run_options;
+        session.Run(run_options, io_binding);
+    }
+
+    // JIT: reload cached context
+    {
+        auto start = std::chrono::high_resolution_clock::now();
+        Ort::SessionOptions so;
+        AppendTrtRtxEp(so);
+        Ort::Session session(*ort_env, toOrtString(model_name_ctx).c_str(), so);
+        auto stop = std::chrono::high_resolution_clock::now();
+        std::cout << "Session creation JIT: "
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(stop - start).count()
+                  << " ms\n";
+
+        auto io_binding = generate_io_binding(session);
+        Ort::RunOptions run_options;
+        session.Run(run_options, io_binding);
+    }
+}
+
+TEST(TensorRTRTXEpTest, ContextEmbedAndReloadDynamic) {
+    const std::string model_name = "nv_execution_provider_dyn_test.onnx";
+    const std::string model_name_ctx = "nv_execution_provider_dyn_test_ctx.onnx";
+    clearFileIfExists(model_name_ctx);
+
+    model_builder::CreateBaseModel(model_name, "test", {1, -1, -1});
+
+    // AOT
+    {
+        Ort::SessionOptions so;
+        so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+        so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, model_name_ctx.c_str());
+        AppendTrtRtxEp(so);
+        Ort::Session session(*ort_env, toOrtString(model_name).c_str(), so);
+
+        auto io_binding = generate_io_binding(session);
+        Ort::RunOptions run_options;
+        session.Run(run_options, io_binding);
+    }
+
+    // JIT with shape overrides
+    {
+        Ort::SessionOptions so;
+        AppendTrtRtxEp(so);
+        Ort::Session session(*ort_env, toOrtString(model_name_ctx).c_str(), so);
+
+        std::map<std::string, std::vector<int64_t>> shape_overwrites;
+        shape_overwrites["X"] = {1, 5, 5};
+        shape_overwrites["Y"] = {1, 5, 1};
+        auto io_binding = generate_io_binding(session, shape_overwrites);
+        Ort::RunOptions run_options;
+        session.Run(run_options, io_binding);
+    }
+}
+
+TEST(TensorRTRTXEpTest, ContextEmbedAndReloadDataDynamic) {
+    const std::string model_name = "nv_execution_provider_data_dyn_test.onnx";
+    const std::string model_name_ctx = "nv_execution_provider_data_dyn_test_ctx.onnx";
+    clearFileIfExists(model_name_ctx);
+
+    model_builder::CreateBaseModel(model_name, "test", {1, -1, -1});
+
+    // AOT
+    {
+        Ort::SessionOptions so;
+        so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+        so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, model_name_ctx.c_str());
+        AppendTrtRtxEp(so);
+        Ort::Session session(*ort_env, toOrtString(model_name).c_str(), so);
+
+        auto io_binding = generate_io_binding(session);
+        Ort::RunOptions run_options;
+        session.Run(run_options, io_binding);
+    }
+
+    // JIT with shape overrides
+    {
+        Ort::SessionOptions so;
+        AppendTrtRtxEp(so);
+        Ort::Session session(*ort_env, toOrtString(model_name_ctx).c_str(), so);
+
+        std::map<std::string, std::vector<int64_t>> shape_overwrites;
+        shape_overwrites["X"] = {1, 5, 5};
+        shape_overwrites["Y"] = {1, 5, 5};
+        auto io_binding = generate_io_binding(session, shape_overwrites);
+        Ort::RunOptions run_options;
+        session.Run(run_options, io_binding);
+    }
+}
+
+// =============================================================================
+// Type tests (parameterized)
+// =============================================================================
+
+static std::string getTypeAsName(int dtype) {
+    switch (dtype) {
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:   return "fp32";
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:  return "fp16";
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16: return "bf16";
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:    return "int64";
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:    return "int32";
+        default: return "unknown";
+    }
+}
+
+class TypeTests : public ::testing::TestWithParam<int> {};
+
+TEST_P(TypeTests, IOTypes) {
+    const int dtype = GetParam();
+    const std::string dtype_name = getTypeAsName(dtype);
+    ASSERT_NE(dtype_name, "unknown");
+
+    const std::string model_name =
+        "nv_execution_provider_" + dtype_name + ".onnx";
+
+    model_builder::CreateBaseModel(model_name, "test_" + dtype_name,
+                                   {1, 5, 10}, false, dtype);
+    {
+        Ort::SessionOptions so;
+        AppendTrtRtxEp(so);
+        Ort::Session session(*ort_env, toOrtString(model_name).c_str(), so);
+
+        auto io_binding = generate_io_binding(session);
+        Ort::RunOptions run_options;
+        session.Run(run_options, io_binding);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TensorRTRTXEpTest, TypeTests,
+    ::testing::Values(
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32),
+    [](const ::testing::TestParamInfo<int>& info) {
+        return getTypeAsName(info.param);
+    });
+
+// =============================================================================
+// TestSessionOutputs
+// =============================================================================
+
+TEST(TensorRTRTXEpTest, TestSessionOutputs) {
+    // Model #1: TopK with 4 outputs of different types
+    {
+        const std::string model_path = "topk_and_multiple_graph_outputs.onnx";
+        model_builder::CreateTopkAndMultipleGraphOutputsModel(model_path);
+
+        Ort::SessionOptions so;
+        AppendTrtRtxEp(so);
+        so.AddFreeDimensionOverrideByName("N", 300);
+        Ort::Session session(*ort_env, toOrtString(model_path).c_str(), so);
+
+        ASSERT_EQ(session.GetOutputCount(), 4u);
+    }
+
+    // Model #2: Dropout with unused mask output
+    {
+        const std::string model_path = "node_output_not_used.onnx";
+        model_builder::CreateNodeOutputNotUsedModel(model_path);
+
+        Ort::SessionOptions so;
+        AppendTrtRtxEp(so);
+        Ort::Session session(*ort_env, toOrtString(model_path).c_str(), so);
+
+        ASSERT_EQ(session.GetOutputCount(), 1u);
+    }
+}
+
+// =============================================================================
+// GetSharedAllocator
+// =============================================================================
+
+TEST(TensorRTRTXEpTest, GetSharedAllocator) {
+    const OrtApi& c_api = Ort::GetApi();
+    auto devices = get_trt_rtx_devices(*ort_env);
+    ASSERT_FALSE(devices.empty());
+
+    const OrtMemoryInfo* device_mem_info =
+        c_api.EpDevice_MemoryInfo(devices[0], OrtDeviceMemoryType_DEFAULT);
+
+    OrtAllocator* allocator = nullptr;
+    Ort::ThrowOnError(c_api.GetSharedAllocator(*ort_env, device_mem_info, &allocator));
+    ASSERT_NE(allocator, nullptr);
+
+    const OrtMemoryInfo* host_mem_info =
+        c_api.EpDevice_MemoryInfo(devices[0], OrtDeviceMemoryType_HOST_ACCESSIBLE);
+
+    OrtAllocator* host_allocator = nullptr;
+    Ort::ThrowOnError(c_api.GetSharedAllocator(*ort_env, host_mem_info, &host_allocator));
+    ASSERT_NE(host_allocator, nullptr);
+}
+
+// =============================================================================
+// LoadUnloadPluginLibrary (C API)
+// =============================================================================
+
+TEST(TensorRTRTXEpTest, LoadUnloadPluginLibrary) {
+    ASSERT_FALSE(g_ep_lib_path.empty()) << "EP library path not set.";
+    const OrtApi& c_api = Ort::GetApi();
+
+    // Unregister the globally registered EP first
+    Ort::ThrowOnError(c_api.UnregisterExecutionProviderLibrary(
+        *ort_env, kEpName));
+
+    // Register
+    Ort::ThrowOnError(c_api.RegisterExecutionProviderLibrary(
+        *ort_env, kEpName, toOrtString(g_ep_lib_path).c_str()));
+
+    // Verify device exists
+    const OrtEpDevice* const* ep_devices = nullptr;
+    size_t num_devices = 0;
+    Ort::ThrowOnError(c_api.GetEpDevices(*ort_env, &ep_devices, &num_devices));
+
+    auto count = std::count_if(
+        ep_devices, ep_devices + num_devices,
+        [&](const OrtEpDevice* d) {
+            return std::string(c_api.EpDevice_EpName(d)) == kEpName;
+        });
+    ASSERT_GE(count, 1) << "Expected at least one OrtEpDevice for TRT RTX EP.";
+
+    // Unregister
+    Ort::ThrowOnError(c_api.UnregisterExecutionProviderLibrary(
+        *ort_env, kEpName));
+
+    // Re-register for subsequent tests
+    Ort::ThrowOnError(c_api.RegisterExecutionProviderLibrary(
+        *ort_env, kEpName, toOrtString(g_ep_lib_path).c_str()));
+}
+
+// =============================================================================
+// LoadUnloadPluginLibraryCxxApi
+// =============================================================================
+
+TEST(TensorRTRTXEpTest, LoadUnloadPluginLibraryCxxApi) {
+    ASSERT_FALSE(g_ep_lib_path.empty()) << "EP library path not set.";
+
+    // Unregister the globally registered EP first
+    ort_env->UnregisterExecutionProviderLibrary(kEpName);
+
+    // Register via C++ API
+    ort_env->RegisterExecutionProviderLibrary(kEpName,
+                                              toOrtString(g_ep_lib_path).c_str());
+
+    auto ep_devices = ort_env->GetEpDevices();
+    auto it = std::find_if(
+        ep_devices.begin(), ep_devices.end(),
+        [](const Ort::ConstEpDevice& d) {
+            return std::string(d.EpName()) == kEpName;
+        });
+    ASSERT_NE(it, ep_devices.end())
+        << "Expected an OrtEpDevice for TRT RTX EP.";
+
+    ASSERT_STREQ(it->EpVendor(), "NVIDIA");
+
+    Ort::ConstHardwareDevice device = it->Device();
+    ASSERT_EQ(device.Type(), OrtHardwareDeviceType_GPU);
+    ASSERT_GE(device.VendorId(), 0);
+    ASSERT_GE(device.DeviceId(), 0);
+    ASSERT_NE(device.Vendor(), nullptr);
+
+    Ort::ConstKeyValuePairs metadata = device.Metadata();
+    auto entries = metadata.GetKeyValuePairs();
+    ASSERT_GT(entries.size(), 0u);
+
+    // Unregister
+    ort_env->UnregisterExecutionProviderLibrary(kEpName);
+
+    // Re-register for subsequent tests
+    ort_env->RegisterExecutionProviderLibrary(kEpName,
+                                              toOrtString(g_ep_lib_path).c_str());
+}
+
+// =============================================================================
+// DataTransfer
+// =============================================================================
+
+TEST(TensorRTRTXEpTest, DataTransfer) {
+    const OrtApi& c_api = Ort::GetApi();
+    auto devices = get_trt_rtx_devices(*ort_env);
+    ASSERT_FALSE(devices.empty());
+
+    const OrtMemoryInfo* device_mem_info =
+        c_api.EpDevice_MemoryInfo(devices[0], OrtDeviceMemoryType_DEFAULT);
+
+    // Create CPU tensor with random data
+    Ort::AllocatorWithDefaultOptions cpu_allocator;
+    std::vector<int64_t> shape{2, 3, 4};
+    const size_t num_elements = 2 * 3 * 4;
+
+    std::mt19937 rng{std::random_device{}()};
+    std::normal_distribution<float> dist(0.0f, 2.0f);
+    std::vector<float> input_data(num_elements);
+    std::generate(input_data.begin(), input_data.end(),
+                  [&]() { return dist(rng); });
+
+    Ort::Value cpu_tensor = Ort::Value::CreateTensor<float>(
+        cpu_allocator.GetInfo(), input_data.data(), input_data.size(),
+        shape.data(), shape.size());
+
+    // Create GPU tensor using shared allocator
+    OrtAllocator* gpu_allocator = nullptr;
+    Ort::ThrowOnError(c_api.GetSharedAllocator(
+        *ort_env, device_mem_info, &gpu_allocator));
+    ASSERT_NE(gpu_allocator, nullptr);
+
+    Ort::Value device_tensor = Ort::Value::CreateTensor<float>(
+        gpu_allocator, shape.data(), shape.size());
+
+    // Copy CPU -> GPU
+    {
+        const OrtValue* src[] = {cpu_tensor};
+        OrtValue* dst[] = {device_tensor};
+        Ort::ThrowOnError(c_api.CopyTensors(
+            *ort_env, src, dst, nullptr, 1));
+    }
+
+    // Copy GPU -> CPU (new tensor)
+    Ort::Value cpu_copy = Ort::Value::CreateTensor<float>(
+        cpu_allocator, shape.data(), shape.size());
+    {
+        const OrtValue* src[] = {device_tensor};
+        OrtValue* dst[] = {cpu_copy};
+        Ort::ThrowOnError(c_api.CopyTensors(
+            *ort_env, src, dst, nullptr, 1));
+    }
+
+    // Verify round-trip data integrity
+    const float* original = cpu_tensor.GetTensorData<float>();
+    const float* copied = cpu_copy.GetTensorData<float>();
+    ASSERT_NE(original, copied) << "Should be different memory locations";
+
+    for (size_t i = 0; i < num_elements; ++i) {
+        EXPECT_FLOAT_EQ(original[i], copied[i])
+            << "Mismatch at index " << i;
+    }
+
+    // Release GPU tensor before EP teardown
+    device_tensor = Ort::Value(nullptr);
+}
+
+// =============================================================================
+// AutoEp_PreferGpu — session picks the TRT RTX EP via PREFER_GPU policy.
+//
+// Note: the ORT public C/C++ API does not expose the list of EPs actually
+// bound to a running session, so (unlike the internal-API source test) we can
+// only verify that session creation and inference succeed with the
+// PREFER_GPU policy and that the TRT RTX EpDevice is visible in the env.
+// =============================================================================
+
+TEST(TensorRTRTXEpTest, AutoEp_PreferGpu) {
+    ASSERT_FALSE(g_ep_lib_path.empty()) << "EP library path not set.";
+
+    const std::string model_name = "nv_execution_provider_auto_ep.onnx";
+    model_builder::CreateBaseModel(model_name, "test", {1, 3, 2});
+
+    // The EP is already registered from main(); verify its device is visible.
+    const auto devices = get_trt_rtx_devices(*ort_env);
+    ASSERT_FALSE(devices.empty())
+        << "TRT RTX EpDevice not visible in env; PREFER_GPU has nothing to pick.";
+
+    Ort::SessionOptions so;
+    so.SetEpSelectionPolicy(OrtExecutionProviderDevicePolicy_PREFER_GPU);
+
+    // Session creation succeeds -> some EP was auto-selected.
+    Ort::Session session(*ort_env, toOrtString(model_name).c_str(), so);
+
+    // Sanity: run inference once so any failure in the selected EP surfaces.
+    auto io_binding = generate_io_binding(session);
+    Ort::RunOptions run_options;
+    session.Run(run_options, io_binding);
+}
+
+// =============================================================================
+// FP8 / FP4 custom-op models — exercise TensorRT FP8 and FP4 custom ops.
+// Both require Blackwell (SM 12.0+) hardware.
+// =============================================================================
+
+TEST(TensorRTRTXEpTest, FP8CustomOpModel) {
+    if (!IsBlackwellOrAbove()) {
+        GTEST_SKIP() << "Test requires SM 12.0+ GPU (Blackwell+).";
+    }
+
+    const std::string model_name =
+        "nv_execution_provider_fp8_quantize_dequantize_test.onnx";
+    clearFileIfExists(model_name);
+
+    model_builder::CreateFP8CustomOpModel(
+        model_name, "nv_execution_provider_fp8_quantize_dequantize_graph");
+    ASSERT_TRUE(std::filesystem::exists(model_name));
+
+    Ort::SessionOptions so;
+    AppendTrtRtxEp(so);
+    Ort::Session session(*ort_env, toOrtString(model_name).c_str(), so);
+
+    ASSERT_EQ(session.GetInputCount(), 1u);
+    ASSERT_EQ(session.GetOutputCount(), 1u);
+
+    // Input: FP16 [4,64] — values in [0, 1). ORT represents FP16 as uint16_t.
+    const std::vector<int64_t> input_shape = {4, 64};
+    const size_t num_elements = 4 * 64;
+    std::vector<uint16_t> input_data(num_elements);
+    for (size_t i = 0; i < num_elements; ++i) {
+        input_data[i] = model_builder::Float32ToFloat16(
+            static_cast<float>(i % 100) / 100.0f);
+    }
+
+    Ort::AllocatorWithDefaultOptions cpu_allocator;
+    Ort::Value input_tensor = Ort::Value::CreateTensor(
+        cpu_allocator.GetInfo(), input_data.data(),
+        input_data.size() * sizeof(uint16_t),
+        input_shape.data(), input_shape.size(),
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
+
+    const char* input_names[]  = {"X"};
+    const char* output_names[] = {"Y"};
+    Ort::RunOptions run_options;
+    auto outputs = session.Run(run_options, input_names, &input_tensor, 1,
+                               output_names, 1);
+
+    ASSERT_EQ(outputs.size(), 1u);
+    ASSERT_TRUE(outputs[0].IsTensor());
+
+    auto out_info = outputs[0].GetTensorTypeAndShapeInfo();
+    ASSERT_EQ(out_info.GetElementType(), ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
+    auto out_shape = out_info.GetShape();
+    ASSERT_EQ(out_shape.size(), 2u);
+    EXPECT_EQ(out_shape[0], 4);
+    EXPECT_EQ(out_shape[1], 64);
+}
+
+TEST(TensorRTRTXEpTest, FP4CustomOpModel) {
+    if (!IsBlackwellOrAbove()) {
+        GTEST_SKIP() << "Test requires SM 12.0+ GPU (Blackwell+).";
+    }
+
+    const std::string model_name =
+        "nv_execution_provider_fp4_dynamic_quantize_test.onnx";
+    clearFileIfExists(model_name);
+
+    model_builder::CreateFP4CustomOpModel(
+        model_name, "nv_execution_provider_fp4_dynamic_quantize_graph");
+    ASSERT_TRUE(std::filesystem::exists(model_name));
+
+    Ort::SessionOptions so;
+    AppendTrtRtxEp(so);
+    Ort::Session session(*ort_env, toOrtString(model_name).c_str(), so);
+
+    ASSERT_EQ(session.GetInputCount(), 1u);
+    ASSERT_EQ(session.GetOutputCount(), 1u);
+
+    // Input: FP16 [64,64]
+    const std::vector<int64_t> input_shape = {64, 64};
+    const size_t num_elements = 64 * 64;
+    std::vector<uint16_t> input_data(num_elements);
+    for (size_t i = 0; i < num_elements; ++i) {
+        input_data[i] = model_builder::Float32ToFloat16(
+            static_cast<float>(i % 100) / 100.0f);
+    }
+
+    Ort::AllocatorWithDefaultOptions cpu_allocator;
+    Ort::Value input_tensor = Ort::Value::CreateTensor(
+        cpu_allocator.GetInfo(), input_data.data(),
+        input_data.size() * sizeof(uint16_t),
+        input_shape.data(), input_shape.size(),
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
+
+    const char* input_names[]  = {"X"};
+    const char* output_names[] = {"X_dequantized"};
+    Ort::RunOptions run_options;
+    auto outputs = session.Run(run_options, input_names, &input_tensor, 1,
+                               output_names, 1);
+
+    ASSERT_EQ(outputs.size(), 1u);
+    ASSERT_TRUE(outputs[0].IsTensor());
+
+    auto out_info = outputs[0].GetTensorTypeAndShapeInfo();
+    ASSERT_EQ(out_info.GetElementType(), ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
+    auto out_shape = out_info.GetShape();
+    ASSERT_EQ(out_shape.size(), 2u);
+    EXPECT_EQ(out_shape[0], 64);
+    EXPECT_EQ(out_shape[1], 64);
+}

--- a/tests/test_tensorrt_rtx_compile_model.cpp
+++ b/tests/test_tensorrt_rtx_compile_model.cpp
@@ -1,0 +1,652 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "test_tensorrt_rtx_utils.h"
+#include <gtest/gtest.h>
+#include <onnxruntime_cxx_api.h>
+#include <onnxruntime_session_options_config_keys.h>
+
+// Use std::thread instead of std::async for concurrent tests.
+#define USE_STD_THREAD 1
+
+extern std::unique_ptr<Ort::Env> ort_env;
+
+// ---------------------------------------------------------------------------
+// Base fixture – checks device availability and model file before every test.
+// ---------------------------------------------------------------------------
+
+class CompileModelTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_FALSE(get_trt_rtx_devices(*ort_env).empty())
+            << "No TRT RTX EP devices found. "
+               "Ensure the EP library is present and an NVIDIA RTX GPU is available.";
+        ASSERT_TRUE(std::filesystem::is_regular_file(kModelPath)) << "Model not found at: " << kModelPath;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Helpers shared by all compile tests
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+constexpr int kNumThreads = 5;
+
+// ---------------------------------------------------------------------------
+// CompileConfig – controls which API paths are exercised in a single compile.
+// ---------------------------------------------------------------------------
+
+struct CompileConfig
+{
+    bool embed_mode;        ///< passed to SetEpContextEmbedMode
+    bool input_from_buffer; ///< use SetInputModelFromBuffer instead of SetInputModelPath
+    bool output_to_buffer;  ///< use SetOutputModelBuffer instead of SetOutputModelPath
+};
+
+/// Short human-readable label used as the GTest parameter suffix.
+std::string config_name(const CompileConfig& c)
+{
+    return std::string(c.embed_mode ? "EmbedOn" : "EmbedOff")
+        + "_In" + (c.input_from_buffer ? "Buf" : "File")
+        + "_Out" + (c.output_to_buffer ? "Buf" : "File");
+}
+
+// ---------------------------------------------------------------------------
+// toOrtDirString – like toOrtString but with a guaranteed trailing separator.
+//
+// ORT's SetEpContextBinaryInformation internally constructs a
+// std::filesystem::path and rejects it when
+//   has_filename() == true && extension() == ""
+// (a bare name without extension looks like a file, not a directory).
+// A trailing '/' makes has_filename() return false, bypassing the check.
+#ifdef _WIN32
+inline std::wstring toOrtDirString(const std::filesystem::path& dir_path)
+{
+    auto s = dir_path.wstring();
+    if (s.empty() || (s.back() != L'/' && s.back() != L'\\'))
+        s += L'/';
+    return s;
+}
+#else
+inline std::string toOrtDirString(const std::filesystem::path& dir_path)
+{
+    auto s = dir_path.string();
+    if (s.empty() || s.back() != '/')
+        s += '/';
+    return s;
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// CompileResult – holds either a file path or an in-memory buffer.
+// ---------------------------------------------------------------------------
+
+struct CompileResult
+{
+    std::filesystem::path path;           ///< non-empty when output went to a file
+    std::vector<char>     buffer;         ///< non-empty when output went to a buffer
+    /// Always set by compile_model_flexible() to the user's intended output path.
+    /// For buffer output + embed_mode=false this also tells the EP where to find the
+    /// external engine binary when the compiled buffer is later loaded into a session
+    /// (passed through kOrtSessionOptionEpContextFilePath in make_session_from_result).
+    std::filesystem::path intended_ctx_path;
+
+    bool is_file()   const { return !path.empty(); }
+    bool is_buffer() const { return !buffer.empty(); }
+};
+
+// ---------------------------------------------------------------------------
+// Session-option factory reused by every test.
+// ---------------------------------------------------------------------------
+
+Ort::SessionOptions make_session_options()
+{
+    // static cudaStream_t stream = nullptr;
+    // if (stream == nullptr)
+    //     cudaStreamCreate(&stream);
+
+    Ort::SessionOptions so;
+    Ort::KeyValuePairs  ep_opts;
+    ep_opts.Add("enable_cuda_graph", "1");
+    ep_opts.Add("nv_runtime_cache_path", "./rt_cache");
+    // ep_opts.Add("has_user_compute_stream", "1");
+    // auto stream_ptr = std::to_string(reinterpret_cast<uint64_t>(stream));
+    // ep_opts.Add("user_compute_stream", stream_ptr.c_str());
+    so.AppendExecutionProvider_V2(*ort_env, get_trt_rtx_devices(*ort_env), ep_opts);
+    return so;
+}
+
+// ---------------------------------------------------------------------------
+// Read an entire file into a byte vector.
+// ---------------------------------------------------------------------------
+
+std::vector<char> read_file_bytes(const std::filesystem::path& p)
+{
+    std::ifstream file(p, std::ios::binary);
+    if (!file)
+        throw std::runtime_error("Cannot open file: " + p.string());
+    return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+}
+
+// ---------------------------------------------------------------------------
+// compile_model_flexible – single compile entry-point for all parameterized tests.
+//
+//   input_path   : ONNX model to compile.
+//   output_path  : always required –
+//                    !cfg.output_to_buffer ? compiled model written here
+//                     cfg.output_to_buffer ? parent/stem provide the binary-
+//                     context location when embed_mode == false
+//
+// Throws std::runtime_error on failure.
+// ---------------------------------------------------------------------------
+
+CompileResult compile_model_flexible(
+    const std::filesystem::path& input_path,
+    const std::filesystem::path& output_path,
+    const CompileConfig&         cfg)
+{
+    auto                         so = make_session_options();
+    Ort::ModelCompilationOptions opts(*ort_env, so);
+    opts.SetEpContextEmbedMode(cfg.embed_mode);
+
+    // -- input --
+    std::vector<char> input_bytes; // must outlive Ort::CompileModel
+    if (cfg.input_from_buffer)
+    {
+        input_bytes = read_file_bytes(input_path);
+        opts.SetInputModelFromBuffer(input_bytes.data(), input_bytes.size());
+    }
+    else
+    {
+        opts.SetInputModelPath(toOrtString(input_path).c_str());
+    }
+
+    // -- output --
+    Ort::AllocatorWithDefaultOptions allocator;
+    void*  out_ptr  = nullptr;
+    size_t out_size = 0;
+
+    if (cfg.output_to_buffer)
+    {
+        opts.SetOutputModelBuffer(allocator, &out_ptr, &out_size);
+        // When not embedding, the binary context still needs a location on disk.
+        if (!cfg.embed_mode)
+        {
+            const auto ctx_dir = output_path.parent_path();
+            std::filesystem::create_directories(ctx_dir);
+            opts.SetEpContextBinaryInformation(
+                toOrtDirString(ctx_dir).c_str(),
+                toOrtString(output_path.stem()).c_str());
+        }
+    }
+    else
+    {
+        opts.SetOutputModelPath(toOrtString(output_path).c_str());
+    }
+
+    const auto status = Ort::CompileModel(*ort_env, opts);
+    if (!status.IsOK())
+        throw std::runtime_error(status.GetErrorMessage());
+
+    CompileResult result;
+    result.intended_ctx_path = output_path;
+    if (cfg.output_to_buffer)
+    {
+        if (out_ptr != nullptr && out_size > 0)
+        {
+            result.buffer.assign(
+                static_cast<char*>(out_ptr),
+                static_cast<char*>(out_ptr) + out_size);
+        }
+        allocator.Free(out_ptr);
+    }
+    else
+    {
+        result.path = output_path;
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// make_session_from_result – open a session from a CompileResult.
+// Each call creates its own SessionOptions (not thread-safe to share).
+// ---------------------------------------------------------------------------
+
+Ort::Session make_session_from_result(const CompileResult& result)
+{
+    auto so = make_session_options();
+
+    // When loading the compiled model from a buffer, there is no on-disk model location
+    // that the EP can use to resolve the relative ep_cache_context path back to an
+    // external engine binary. Follow the same pattern as the QNN EP tests and pass the
+    // intended context-model path via kOrtSessionOptionEpContextFilePath so the EP can
+    // anchor the relative path lookup to the correct directory.
+    if (result.is_buffer() && !result.intended_ctx_path.empty())
+    {
+        so.AddConfigEntry(kOrtSessionOptionEpContextFilePath,
+                          result.intended_ctx_path.string().c_str());
+    }
+
+    if (result.is_file())
+        return Ort::Session(*ort_env, toOrtString(result.path).c_str(), so);
+    return Ort::Session(*ort_env, result.buffer.data(), result.buffer.size(), so);
+}
+
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// Parameterized fixture – inherits SetUp checks from CompileModelTest.
+// ---------------------------------------------------------------------------
+
+class CompileModelParamTest
+    : public CompileModelTest
+    , public ::testing::WithParamInterface<CompileConfig>
+{};
+
+// ---------------------------------------------------------------------------
+// Test 1: single-threaded compile then session load + shape check.
+// ---------------------------------------------------------------------------
+
+TEST_P(CompileModelParamTest, CompilesModel)
+{
+    const auto& cfg         = GetParam();
+    const auto  output_path = kModelPath.parent_path() / "context.onnx";
+    std::filesystem::remove(output_path);
+
+    CompileResult result;
+    ASSERT_NO_THROW(result = compile_model_flexible(kModelPath, output_path, cfg));
+
+    if (result.is_file())
+    {
+        ASSERT_TRUE(std::filesystem::is_regular_file(result.path))
+            << "Compiled model not found at: " << result.path;
+    }
+    else
+    {
+        ASSERT_FALSE(result.buffer.empty()) << "Output buffer is empty after compilation";
+    }
+
+    // Verify the compiled model loads into a valid session.
+    Ort::Session session{nullptr};
+    ASSERT_NO_THROW(session = make_session_from_result(result));
+    EXPECT_EQ(session.GetInputCount(),  1u);
+    EXPECT_EQ(session.GetOutputCount(), 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: kNumThreads concurrent compilations of the same source model,
+//         each writing to a unique output destination.
+// ---------------------------------------------------------------------------
+
+TEST_P(CompileModelParamTest, ConcurrentCompile)
+{
+    const auto& cfg = GetParam();
+
+    std::vector<std::filesystem::path> output_paths(kNumThreads);
+    for (int i = 0; i < kNumThreads; ++i)
+    {
+        output_paths[i] =
+            kModelPath.parent_path() / ("context_thread_" + std::to_string(i) + ".onnx");
+        std::filesystem::remove(output_paths[i]);
+    }
+
+#if USE_STD_THREAD
+    std::vector<CompileResult>      results(kNumThreads);
+    std::vector<std::exception_ptr> exceptions(kNumThreads);
+    std::vector<std::thread>        threads;
+    threads.reserve(kNumThreads);
+
+    for (int i = 0; i < kNumThreads; ++i)
+    {
+        threads.emplace_back(
+            [&output_paths, &results, &exceptions, &cfg, i]()
+            {
+                try
+                {
+                    results[i] = compile_model_flexible(kModelPath, output_paths[i], cfg);
+                }
+                catch (...)
+                {
+                    exceptions[i] = std::current_exception();
+                }
+            });
+    }
+    for (auto& t : threads)
+        t.join();
+
+    for (int i = 0; i < kNumThreads; ++i)
+    {
+        EXPECT_FALSE(exceptions[i]) << "Thread " << i << " compilation failed";
+        if (!exceptions[i])
+        {
+            if (results[i].is_file())
+                EXPECT_TRUE(std::filesystem::is_regular_file(results[i].path))
+                    << "Thread " << i << " output file missing: " << results[i].path;
+            else
+                EXPECT_FALSE(results[i].buffer.empty())
+                    << "Thread " << i << " output buffer is empty";
+        }
+    }
+#else
+    std::vector<std::future<CompileResult>> futures;
+    futures.reserve(kNumThreads);
+    for (int i = 0; i < kNumThreads; ++i)
+    {
+        futures.push_back(std::async(std::launch::async,
+            [&output_paths, &cfg, i]()
+            {
+                return compile_model_flexible(kModelPath, output_paths[i], cfg);
+            }));
+    }
+
+    for (int i = 0; i < kNumThreads; ++i)
+    {
+        CompileResult result;
+        ASSERT_NO_THROW(result = futures[i].get()) << "Thread " << i << " compilation failed";
+        if (result.is_file())
+            EXPECT_TRUE(std::filesystem::is_regular_file(result.path))
+                << "Thread " << i << " output file missing: " << result.path;
+        else
+            EXPECT_FALSE(result.buffer.empty())
+                << "Thread " << i << " output buffer is empty";
+    }
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: compile once, then kNumThreads sessions are instantiated concurrently
+//         from the same result, followed by sequential inference on each.
+// ---------------------------------------------------------------------------
+
+//(TODO) Enable after fix
+/*
+TEST_P(CompileModelParamTest, ConcurrentSessionInstantiationAndSequentialInference)
+{
+    const auto& cfg      = GetParam();
+    const auto  ctx_path = kModelPath.parent_path() / "context_concurrent.onnx";
+    std::filesystem::remove(ctx_path);
+
+    // Compile once (single-threaded).
+    CompileResult compiled;
+    ASSERT_NO_THROW(compiled = compile_model_flexible(kModelPath, ctx_path, cfg));
+
+#if USE_STD_THREAD
+    std::vector<std::unique_ptr<Ort::Session>> sessions(kNumThreads);
+    std::vector<std::exception_ptr>            exceptions(kNumThreads);
+    std::vector<std::thread>                   threads;
+    threads.reserve(kNumThreads);
+
+    for (int i = 0; i < kNumThreads; ++i)
+    {
+        threads.emplace_back(
+            [&compiled, &sessions, &exceptions, i]()
+            {
+                try
+                {
+                    sessions[i] =
+                        std::make_unique<Ort::Session>(make_session_from_result(compiled));
+                }
+                catch (...)
+                {
+                    exceptions[i] = std::current_exception();
+                }
+            });
+    }
+    for (auto& t : threads)
+        t.join();
+    for (int i = 0; i < kNumThreads; ++i)
+        ASSERT_FALSE(exceptions[i]) << "Thread " << i << " failed to instantiate session";
+#else
+    std::vector<std::future<std::unique_ptr<Ort::Session>>> futures;
+    futures.reserve(kNumThreads);
+    for (int i = 0; i < kNumThreads; ++i)
+    {
+        futures.push_back(std::async(std::launch::async,
+            [&compiled]()
+            {
+                return std::make_unique<Ort::Session>(make_session_from_result(compiled));
+            }));
+    }
+
+    std::vector<std::unique_ptr<Ort::Session>> sessions;
+    sessions.reserve(kNumThreads);
+    for (int i = 0; i < kNumThreads; ++i)
+        ASSERT_NO_THROW(sessions.push_back(futures[i].get()))
+            << "Thread " << i << " failed to instantiate session";
+#endif
+
+    // Sequential inference on each session.
+    for (int i = 0; i < static_cast<int>(sessions.size()); ++i)
+    {
+        ASSERT_NE(sessions[i], nullptr);
+        ASSERT_NO_THROW(run_with_cpu_bindings(*sessions[i], 1)) << "Inference failed on session " << i;
+    }
+}
+*/
+
+// ---------------------------------------------------------------------------
+// Instantiate all 8 combinations: embed × input-mode × output-mode
+// ---------------------------------------------------------------------------
+
+INSTANTIATE_TEST_SUITE_P(
+    TensorRTRTXEpTest_AllModes,
+    CompileModelParamTest,
+    ::testing::Values(
+        CompileConfig{false, false, false},
+        CompileConfig{false, false, true },
+        CompileConfig{false, true,  false},
+        CompileConfig{false, true,  true },
+        CompileConfig{true,  false, false},
+        CompileConfig{true,  false, true },
+        CompileConfig{true,  true,  false},
+        CompileConfig{true,  true,  true }
+    ),
+    [](const ::testing::TestParamInfo<CompileConfig>& info)
+    {
+        return config_name(info.param);
+    });
+
+// ---------------------------------------------------------------------------
+// Special-character and runtime-cache path tests
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+// Returns a subdirectory under the model directory whose name exercises:
+//   - spaces
+//   - parentheses
+//   - the Unicode character é (U+00E9), common in European user paths
+//
+// On Windows the path is constructed from a wide-string literal so that
+// std::filesystem::path carries the correct wchar_t encoding regardless
+// of the system codepage.
+inline std::filesystem::path special_chars_base_dir()
+{
+#ifdef _WIN32
+    return kModelPath.parent_path()
+        / std::filesystem::path{L"special (chars) r\u00e9sum\u00e9"};
+#else
+    return kModelPath.parent_path()
+        / std::filesystem::path{u8"special (chars) r\u00e9sum\u00e9"};
+#endif
+}
+
+// Compile input_path ? output_path (embed_mode=true, file-to-file) and point
+// nv_runtime_cache_path at cache_dir.  Pass an empty cache_dir to omit the option.
+void compile_with_cache(
+    const std::filesystem::path& input_path,
+    const std::filesystem::path& output_path,
+    const std::filesystem::path& cache_dir = {},
+    const std::string& cache_dir_str = {})
+{
+    Ort::SessionOptions so;
+    Ort::KeyValuePairs  ep_opts;
+    ep_opts.Add("enable_cuda_graph", "1");
+    if (!cache_dir.empty())
+    {
+        ep_opts.Add("nv_runtime_cache_path", cache_dir.string().c_str());
+    }
+    so.AppendExecutionProvider_V2(*ort_env, get_trt_rtx_devices(*ort_env), ep_opts);
+
+    Ort::ModelCompilationOptions opts(*ort_env, so);
+    opts.SetEpContextEmbedMode(true);
+    opts.SetInputModelPath(toOrtString(input_path).c_str());
+    opts.SetOutputModelPath(toOrtString(output_path).c_str());
+    const auto status = Ort::CompileModel(*ort_env, opts);
+    if (!status.IsOK())
+        throw std::runtime_error(status.GetErrorMessage());
+}
+
+// Create a session from a compiled context file with a specific runtime cache directory.
+Ort::Session make_session_with_cache(
+    const std::filesystem::path& ctx_path,
+    const std::filesystem::path& cache_dir)
+{
+    Ort::SessionOptions so;
+    Ort::KeyValuePairs  ep_opts;
+    ep_opts.Add("enable_cuda_graph", "1");
+    ep_opts.Add("nv_runtime_cache_path", cache_dir.string().c_str());
+    so.AppendExecutionProvider_V2(*ort_env, get_trt_rtx_devices(*ort_env), ep_opts);
+    return Ort::Session(*ort_env, toOrtString(ctx_path).c_str(), so);
+}
+
+// Returns true if dir contains at least one regular file (ignores sub-dirs).
+bool dir_has_files(const std::filesystem::path& dir)
+{
+    std::error_code ec;
+    for (const auto& e : std::filesystem::directory_iterator(dir, ec))
+        if (e.is_regular_file())
+            return true;
+    return false;
+}
+
+} // anonymous namespace
+
+class TensorRTRTXEpTest_PathTest : public CompileModelTest {};
+
+// -- Context input path: source ONNX lives on a path with special characters -
+
+TEST_F(TensorRTRTXEpTest_PathTest, ContextInputPathSpecialChars)
+{
+    const auto src_dir  = special_chars_base_dir() / "input";
+    const auto src_copy = src_dir / kModelPath.filename();
+    const auto ctx_path = special_chars_base_dir() / "ctx_from_special" / "context.onnx";
+
+    std::filesystem::create_directories(src_dir);
+    std::filesystem::create_directories(ctx_path.parent_path());
+    std::filesystem::copy_file(kModelPath, src_copy,
+                               std::filesystem::copy_options::overwrite_existing);
+
+    CompileResult result;
+    ASSERT_NO_THROW(result = compile_model_flexible(src_copy, ctx_path,
+                                                    CompileConfig{true, false, false}));
+    ASSERT_TRUE(std::filesystem::is_regular_file(result.path));
+
+    Ort::Session session{nullptr};
+    ASSERT_NO_THROW(session = make_session_from_result(result));
+    EXPECT_EQ(session.GetInputCount(),  1u);
+    EXPECT_EQ(session.GetOutputCount(), 1u);
+}
+
+// -- Context output path: compiled context model written to a special-chars path
+
+TEST_F(TensorRTRTXEpTest_PathTest, ContextOutputPathSpecialChars)
+{
+    const auto ctx_path = special_chars_base_dir() / "ctx_to_special" / "context.onnx";
+    std::filesystem::create_directories(ctx_path.parent_path());
+
+    CompileResult result;
+    ASSERT_NO_THROW(result = compile_model_flexible(kModelPath, ctx_path,
+                                                    CompileConfig{true, false, false}));
+    ASSERT_TRUE(std::filesystem::is_regular_file(result.path));
+
+    Ort::Session session{nullptr};
+    ASSERT_NO_THROW(session = make_session_from_result(result));
+    EXPECT_EQ(session.GetInputCount(),  1u);
+    EXPECT_EQ(session.GetOutputCount(), 1u);
+}
+
+// -- nv_runtime_cache_path: plain ASCII directory ----------------------------
+
+TEST_F(TensorRTRTXEpTest_PathTest, RuntimeCacheNormalPath)
+{
+    const auto cache_dir = kModelPath.parent_path() / "rt_cache_normal_test";
+    const auto ctx_path  = kModelPath.parent_path() / "rt_cache_normal_ctx" / "context.onnx";
+    std::filesystem::create_directories(ctx_path.parent_path());
+
+    ASSERT_NO_THROW(compile_with_cache(kModelPath, ctx_path, cache_dir));
+    ASSERT_TRUE(std::filesystem::is_regular_file(ctx_path));
+
+    // First session: EP creates the engine and writes the cache on destruction.
+    {
+        Ort::Session s = make_session_with_cache(ctx_path, cache_dir);
+        EXPECT_EQ(s.GetInputCount(),  1u);
+        EXPECT_EQ(s.GetOutputCount(), 1u);
+        ASSERT_NO_THROW(run_with_cpu_bindings(s, 1));
+    } // IExecutionContextDeleter fires here ? cache serialized
+
+    EXPECT_TRUE(dir_has_files(cache_dir))
+        << "Expected runtime cache files in: " << cache_dir;
+
+    // Second session: EP should deserialize from the written cache.
+    ASSERT_NO_THROW({
+        Ort::Session s = make_session_with_cache(ctx_path, cache_dir);
+        EXPECT_EQ(s.GetInputCount(),  1u);
+        EXPECT_EQ(s.GetOutputCount(), 1u);
+    });
+}
+
+// -- nv_runtime_cache_path: directory with special characters ----------------
+
+TEST_F(TensorRTRTXEpTest_PathTest, RuntimeCacheSpecialCharsPath)
+{
+    const auto cache_dir = special_chars_base_dir() / "rt_cache";
+    const auto ctx_path  = special_chars_base_dir() / "rt_cache_ctx" / "context.onnx";
+    std::filesystem::create_directories(ctx_path.parent_path());
+
+    ASSERT_NO_THROW(compile_with_cache(kModelPath, ctx_path, cache_dir));
+    ASSERT_TRUE(std::filesystem::is_regular_file(ctx_path));
+
+    // First session: EP creates the engine and writes the cache on destruction.
+    {
+        Ort::Session s = make_session_with_cache(ctx_path, cache_dir);
+        EXPECT_EQ(s.GetInputCount(),  1u);
+        EXPECT_EQ(s.GetOutputCount(), 1u);
+        ASSERT_NO_THROW(run_with_cpu_bindings(s, 1));
+    } // IExecutionContextDeleter fires here ? cache serialized
+
+    EXPECT_TRUE(dir_has_files(cache_dir))
+        << "Expected runtime cache files in: " << cache_dir;
+
+    // Second session: EP should deserialize from the special-chars cache path.
+    ASSERT_NO_THROW({
+        Ort::Session s = make_session_with_cache(ctx_path, cache_dir);
+        EXPECT_EQ(s.GetInputCount(),  1u);
+        EXPECT_EQ(s.GetOutputCount(), 1u);
+    });
+}
+

--- a/tests/test_tensorrt_rtx_ep_context.cpp
+++ b/tests/test_tensorrt_rtx_ep_context.cpp
@@ -1,0 +1,699 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ported from onnxruntime/test/providers/nv_tensorrt_rtx/nv_ep_context_test.cc
+// Uses only public ORT SDK APIs.
+
+#include <gtest/gtest.h>
+#include <onnxruntime_cxx_api.h>
+#include <onnxruntime_session_options_config_keys.h>
+
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include "test_tensorrt_rtx_model_builder.h"
+#include "test_tensorrt_rtx_utils.h"
+
+extern std::unique_ptr<Ort::Env> ort_env;
+
+// Helper: append TRT RTX EP to session options.
+static void AppendTrtRtxEp(
+    Ort::SessionOptions& so,
+    const std::unordered_map<std::string, std::string>& options = {}) {
+    auto devices = get_trt_rtx_devices(*ort_env);
+    ASSERT_FALSE(devices.empty()) << "No TRT RTX EP devices found.";
+    Ort::KeyValuePairs kv_options;
+    for (auto& [k, v] : options) {
+        kv_options.Add(k.c_str(), v.c_str());
+    }
+    so.AppendExecutionProvider_V2(*ort_env, devices, kv_options);
+}
+
+// Helper: read a file into a byte vector.
+static std::vector<char> readBinaryFile(const std::string& path) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file.is_open()) {
+        throw std::runtime_error("Could not open file: " + path);
+    }
+    file.seekg(0, std::ios::end);
+    if (!file.good()) {
+        throw std::runtime_error("Failed to seek in file: " + path);
+    }
+    auto size = file.tellg();
+    if (size < 0) {
+        throw std::runtime_error("Failed to determine size of file: " + path);
+    }
+    file.seekg(0, std::ios::beg);
+    std::vector<char> buf(static_cast<size_t>(size));
+    if (!file.read(buf.data(), size)) {
+        throw std::runtime_error("Failed to read " + std::to_string(size)
+                                 + " bytes from file: " + path);
+    }
+    return buf;
+}
+
+static std::string readTextFile(const std::filesystem::path& path) {
+    std::ifstream file(path, std::ios::in | std::ios::binary);
+    if (!file.is_open()) {
+        throw std::runtime_error("Could not open text file: " + path.string());
+    }
+    return std::string(std::istreambuf_iterator<char>(file),
+                       std::istreambuf_iterator<char>());
+}
+
+static onnx::ModelProto readOnnxModel(const std::filesystem::path& path) {
+    std::ifstream file(path, std::ios::in | std::ios::binary);
+    if (!file.is_open()) {
+        throw std::runtime_error("Could not open ONNX model: " + path.string());
+    }
+
+    onnx::ModelProto model;
+    if (!model.ParseFromIstream(&file)) {
+        throw std::runtime_error("Failed to parse ONNX model: " + path.string());
+    }
+    return model;
+}
+
+static size_t countNodesByOpType(
+    const onnx::GraphProto& graph,
+    const std::string& op_type,
+    const std::string& domain = "") {
+    size_t count = 0;
+    for (const auto& node : graph.node()) {
+        if (node.op_type() == op_type &&
+            (domain.empty() || node.domain() == domain)) {
+            ++count;
+        }
+
+        for (const auto& attr : node.attribute()) {
+            if (attr.type() == onnx::AttributeProto_AttributeType_GRAPH) {
+                count += countNodesByOpType(attr.g(), op_type, domain);
+            } else if (attr.type() == onnx::AttributeProto_AttributeType_GRAPHS) {
+                for (const auto& nested_graph : attr.graphs()) {
+                    count += countNodesByOpType(nested_graph, op_type, domain);
+                }
+            }
+        }
+    }
+
+    return count;
+}
+
+static std::vector<float> ComputeFastGeluReference(
+    const std::vector<float>& input_data) {
+    std::vector<float> output;
+    output.reserve(input_data.size());
+
+    for (float x : input_data) {
+        const float y =
+            x * (0.5f + 0.5f * std::tanh(x * (0.035677408136300125f * x * x +
+                                              0.7978845608028654f)));
+        output.push_back(y);
+    }
+
+    return output;
+}
+
+static std::vector<float> ComputeExpectedLoweredAsymmetricDqMatMulFastGeluOutput(
+    const std::vector<float>& x_data) {
+    constexpr int kRows = 2;
+    constexpr int kInner = 3;
+    constexpr int kCols = 2;
+    const std::vector<int8_t> q_weights = {16, -8, 5, 12, -3, 9};
+    constexpr int8_t kZeroPoint = 3;
+    constexpr float kScale = 0.25f;
+
+    std::vector<float> dequantized_weights;
+    dequantized_weights.reserve(q_weights.size());
+    for (const int8_t q : q_weights) {
+        dequantized_weights.push_back(
+            (static_cast<float>(q) - static_cast<float>(kZeroPoint)) * kScale);
+    }
+
+    std::vector<float> matmul_output(kRows * kCols, 0.0f);
+    for (int row = 0; row < kRows; ++row) {
+        for (int col = 0; col < kCols; ++col) {
+            float acc = 0.0f;
+            for (int inner = 0; inner < kInner; ++inner) {
+                acc += x_data[row * kInner + inner] *
+                       dequantized_weights[inner * kCols + col];
+            }
+            matmul_output[row * kCols + col] = acc;
+        }
+    }
+
+    return ComputeFastGeluReference(matmul_output);
+}
+
+static std::vector<float> ComputeExpectedLoweredAsymmetricQdqMatMulFastGeluOutput(
+    const std::vector<float>& x_data) {
+    constexpr int kRows = 2;
+    constexpr int kInner = 3;
+    constexpr int kCols = 2;
+    constexpr float kScale = 0.25f;
+    constexpr int8_t kZeroPoint = 5;
+    constexpr int32_t kQMin = -128;
+    constexpr int32_t kQMax = 127;
+    const std::vector<float> weights = {
+        1.25f, -0.75f,
+        0.50f,  2.00f,
+       -1.50f,  0.25f};
+
+    std::vector<float> dequantized_x;
+    dequantized_x.reserve(x_data.size());
+    for (float x : x_data) {
+        const float shifted = std::nearbyint(x / kScale) +
+                              static_cast<float>(kZeroPoint);
+        const int32_t clamped = std::max(
+            kQMin, std::min(kQMax, static_cast<int32_t>(shifted)));
+        const int8_t quantized = static_cast<int8_t>(clamped);
+        dequantized_x.push_back(
+            (static_cast<float>(quantized) - static_cast<float>(kZeroPoint)) *
+            kScale);
+    }
+
+    std::vector<float> matmul_output(kRows * kCols, 0.0f);
+    for (int row = 0; row < kRows; ++row) {
+        for (int col = 0; col < kCols; ++col) {
+            float acc = 0.0f;
+            for (int inner = 0; inner < kInner; ++inner) {
+                acc += dequantized_x[row * kInner + inner] *
+                       weights[inner * kCols + col];
+            }
+            matmul_output[row * kCols + col] = acc;
+        }
+    }
+
+    return ComputeFastGeluReference(matmul_output);
+}
+
+// =============================================================================
+// CompileApiTest — parameterized
+// =============================================================================
+
+struct CompileParam {
+    bool embed_mode;
+    bool bytestream_io;
+    bool external_initializer_for_parser = false;
+
+    std::string to_string() const {
+        return "embed_mode_" + std::to_string(embed_mode)
+             + "_bytestream_io_" + std::to_string(bytestream_io)
+             + "_ext_init_" + std::to_string(external_initializer_for_parser);
+    }
+};
+
+class CompileApiTest
+    : public ::testing::TestWithParam<CompileParam> {
+ protected:
+    void SetUp() override {
+        ASSERT_FALSE(get_trt_rtx_devices(*ort_env).empty())
+            << "No TRT RTX EP devices found.";
+    }
+};
+
+static void SmallModelTest(CompileParam test_param, bool fully_supported_model) {
+    std::string test_name = test_param.to_string();
+    if (!fully_supported_model) test_name += "_fast_gelu";
+
+    const std::string model_name =
+        "nv_execution_provider_compile_" + test_name + ".onnx";
+    const std::string model_name_ctx =
+        "nv_execution_provider_compile_" + test_name + "_ctx.onnx";
+    clearFileIfExists(model_name_ctx);
+
+    model_builder::CreateBaseModel(
+        model_name, "test", {1, 3, 2}, !fully_supported_model);
+
+    Ort::SessionOptions session_options;
+    AppendTrtRtxEp(session_options,
+                   {{"nv_use_external_data_initializer",
+                     std::to_string(test_param.external_initializer_for_parser)}});
+
+    Ort::ModelCompilationOptions compile_opts(*ort_env, session_options);
+    compile_opts.SetEpContextEmbedMode(test_param.embed_mode);
+
+    void* output_context = nullptr;
+    size_t output_context_size = 0;
+    std::vector<char> input_onnx;
+
+    if (test_param.bytestream_io) {
+        input_onnx = readBinaryFile(model_name);
+        compile_opts.SetInputModelFromBuffer(input_onnx.data(), input_onnx.size());
+        compile_opts.SetOutputModelBuffer(
+            Ort::AllocatorWithDefaultOptions(), &output_context, &output_context_size);
+    } else {
+        compile_opts.SetInputModelPath(toOrtString(model_name).c_str());
+        compile_opts.SetOutputModelPath(toOrtString(model_name_ctx).c_str());
+    }
+
+    // AOT compile
+    ASSERT_TRUE(Ort::CompileModel(*ort_env, compile_opts).IsOK());
+
+    // JIT: load compiled model and run inference
+    Ort::Session session{nullptr};
+    if (test_param.bytestream_io) {
+        session = Ort::Session(*ort_env, output_context, output_context_size,
+                               session_options);
+        Ort::AllocatorWithDefaultOptions().Free(output_context);
+    } else {
+        session = Ort::Session(*ort_env, toOrtString(model_name_ctx).c_str(),
+                               session_options);
+    }
+
+    auto io_binding = generate_io_binding(session);
+    Ort::RunOptions run_options;
+    session.Run(run_options, io_binding);
+}
+
+TEST_P(CompileApiTest, SmallModel) {
+    SmallModelTest(GetParam(), /*fully_supported_model=*/true);
+}
+
+TEST_P(CompileApiTest, SmallSplitModel) {
+    SmallModelTest(GetParam(), /*fully_supported_model=*/false);
+}
+
+// Large model compilation with external-data I/O. embed_mode=1 is skipped
+// because an embedded context for a large model would exceed the 2 GB proto
+// limit.
+TEST_P(CompileApiTest, LargeModel) {
+    const CompileParam test_param = GetParam();
+    if (test_param.embed_mode) {
+        GTEST_SKIP() << "embed_mode=1 would exceed 2GB proto limit for large model.";
+    }
+
+    const std::string test_name = test_param.to_string();
+    const std::string model_name =
+        "nv_execution_provider_compile_large_" + test_name + ".onnx";
+    const std::string external_data_name =
+        "nv_execution_provider_compile_large_" + test_name + ".onnx_data";
+    const std::string model_name_ctx =
+        "nv_execution_provider_compile_large_" + test_name + "_ctx.onnx";
+    const std::string model_name_ctx_data =
+        "nv_execution_provider_compile_large_" + test_name + "_ctx.onnx_data";
+    clearFileIfExists(model_name_ctx);
+    clearFileIfExists(model_name_ctx_data);
+
+    // Reuse the model across test iterations for speed.
+    if (!std::filesystem::exists(model_name) ||
+        !std::filesystem::exists(external_data_name)) {
+        model_builder::CreateLargeModel(model_name, external_data_name);
+    }
+
+    Ort::SessionOptions session_options;
+    AppendTrtRtxEp(session_options,
+                   {{"nv_use_external_data_initializer",
+                     std::to_string(test_param.bytestream_io ||
+                                    test_param.external_initializer_for_parser)}});
+
+    Ort::ModelCompilationOptions compile_opts(*ort_env, session_options);
+    compile_opts.SetEpContextEmbedMode(test_param.embed_mode);
+
+    void* output_context = nullptr;
+    size_t output_context_size = 0;
+    std::vector<char> input_onnx;
+    std::vector<char> input_data;
+    std::vector<std::basic_string<ORTCHAR_T>> ext_file_names;
+    std::vector<char*> ext_file_buffers;
+    std::vector<size_t> ext_lengths;
+
+    if (test_param.bytestream_io) {
+        input_onnx = readBinaryFile(model_name);
+        input_data = readBinaryFile(external_data_name);
+        // "location" stored in the ONNX model is the filename only (see
+        // CreateLargeModel). Match that here so ORT can resolve the mapping.
+        const auto filename = std::filesystem::path(external_data_name).filename();
+        ext_file_names   = {toOrtString(filename)};
+        ext_file_buffers = {input_data.data()};
+        ext_lengths      = {input_data.size()};
+        session_options.AddExternalInitializersFromFilesInMemory(
+            ext_file_names, ext_file_buffers, ext_lengths);
+
+        compile_opts.SetInputModelFromBuffer(input_onnx.data(), input_onnx.size());
+        compile_opts.SetOutputModelBuffer(
+            Ort::AllocatorWithDefaultOptions(), &output_context, &output_context_size);
+    } else {
+        compile_opts.SetInputModelPath(toOrtString(model_name).c_str());
+        compile_opts.SetOutputModelPath(toOrtString(model_name_ctx).c_str());
+        compile_opts.SetOutputModelExternalInitializersFile(
+            toOrtString(model_name_ctx_data).c_str(), 1024);
+    }
+
+    ASSERT_TRUE(Ort::CompileModel(*ort_env, compile_opts).IsOK());
+
+    // JIT: load compiled model and run inference
+    std::unique_ptr<Ort::Session> session;
+    if (test_param.bytestream_io) {
+        session = std::make_unique<Ort::Session>(
+            *ort_env, output_context, output_context_size, session_options);
+    } else {
+        session = std::make_unique<Ort::Session>(
+            *ort_env, toOrtString(model_name_ctx).c_str(), session_options);
+    }
+
+    auto io_binding = generate_io_binding(*session);
+    Ort::RunOptions run_options;
+    session->Run(run_options, io_binding);
+
+    if (output_context != nullptr) {
+        Ort::AllocatorWithDefaultOptions().Free(output_context);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TensorRTRTXEpTest_EpContext, CompileApiTest,
+    ::testing::Values(
+        CompileParam{true, false},
+        CompileParam{false, false},
+        CompileParam{true, true},
+        CompileParam{false, true},
+        CompileParam{true, true, true},
+        CompileParam{true, false, true}),
+    [](const ::testing::TestParamInfo<CompileApiTest::ParamType>& info) {
+        return info.param.to_string();
+    });
+
+// Validates the runtime split-graph path for lowered asymmetric DQ:
+//   * the constant-weight DequantizeLinear(zp != 0) + MatMul region stays on TRT-RTX
+//   * FastGelu is intentionally excluded from TRT-RTX and executes on CPU
+//   * the final output still matches a CPU-side golden reference for the full graph
+TEST(TensorRTRTXEpTest_EpContext, LoweredAsymmetricDqMatMulPreservesSplitGraph) {
+    ASSERT_FALSE(get_trt_rtx_devices(*ort_env).empty())
+        << "No TRT RTX EP devices found.";
+
+    const std::string model_path =
+        "ep_context_lowered_asymmetric_dq_fast_gelu.onnx";
+    clearFileIfExists(model_path);
+
+    model_builder::CreateAsymmetricDqMatMulFastGeluModel(
+        model_path, "LoweredAsymmetricDqFastGeluGraph");
+
+    Ort::SessionOptions session_options;
+    // FastGelu is intentionally kept on CPU so this test can validate a stable
+    // mixed-partition graph: the asymmetric DQ+MatMul region on TRT-RTX and
+    // FastGelu on CPU.
+    AppendTrtRtxEp(session_options, {{"nv_op_types_to_exclude", "FastGelu"}});
+    const std::filesystem::path profile_prefix =
+        "ep_context_lowered_asymmetric_dq_fast_gelu_profile";
+    session_options.EnableProfiling(toOrtString(profile_prefix).c_str());
+
+    Ort::Session session(*ort_env, toOrtString(model_path).c_str(), session_options);
+    Ort::RunOptions run_options;
+
+    const std::vector<int64_t> input_shape = {2, 3};
+    const std::vector<float> input_data = {
+        1.0f, 2.0f, -1.0f,
+        0.5f, -0.25f, 3.0f};
+    const std::vector<float> expected_output =
+        ComputeExpectedLoweredAsymmetricDqMatMulFastGeluOutput(input_data);
+
+    Ort::AllocatorWithDefaultOptions allocator;
+    Ort::Value input_tensor = Ort::Value::CreateTensor<float>(
+        allocator.GetInfo(), const_cast<float*>(input_data.data()), input_data.size(),
+        input_shape.data(), input_shape.size());
+    const char* input_names[] = {"X"};
+    const char* output_names[] = {"O"};
+
+    std::vector<Ort::Value> outputs;
+    ASSERT_NO_THROW(outputs = session.Run(run_options, input_names, &input_tensor,
+                                          1, output_names, 1));
+    ASSERT_EQ(outputs.size(), 1u);
+    ASSERT_TRUE(outputs[0].IsTensor());
+
+    const auto output_info = outputs[0].GetTensorTypeAndShapeInfo();
+    EXPECT_EQ(output_info.GetElementCount(), expected_output.size());
+    const float* output_data = outputs[0].GetTensorData<float>();
+    for (size_t i = 0; i < expected_output.size(); ++i) {
+        EXPECT_NEAR(output_data[i], expected_output[i], 1e-5f)
+            << "Mismatch at output index " << i;
+    }
+
+    auto profile_path_alloc = session.EndProfilingAllocated(allocator);
+    ASSERT_NE(profile_path_alloc.get(), nullptr);
+
+    const std::filesystem::path profile_path{profile_path_alloc.get()};
+    ASSERT_TRUE(std::filesystem::is_regular_file(profile_path))
+        << "Profiling output not found at: " << profile_path.string();
+
+    const std::string profile = readTextFile(profile_path);
+
+    EXPECT_NE(profile.find("FastGelu"), std::string::npos)
+        << "Expected FastGelu to appear in ORT profiling output";
+    EXPECT_NE(profile.find("CPUExecutionProvider"), std::string::npos)
+        << "Expected CPUExecutionProvider to appear in ORT profiling output";
+    EXPECT_NE(profile.find(kEpName), std::string::npos)
+        << "Expected NvTensorRTRTXExecutionProvider to appear in ORT profiling output";
+}
+
+// Validates the runtime split-graph path for lowered asymmetric Q->DQ:
+//   * the QuantizeLinear/DequantizeLinear + MatMul region stays on TRT-RTX
+//   * FastGelu is intentionally excluded from TRT-RTX and executes on CPU
+//   * the final output still matches a CPU-side golden reference for the full graph
+TEST(TensorRTRTXEpTest_EpContext, LoweredAsymmetricQdqMatMulPreservesSplitGraph) {
+    ASSERT_FALSE(get_trt_rtx_devices(*ort_env).empty())
+        << "No TRT RTX EP devices found.";
+
+    const std::string model_path =
+        "ep_context_lowered_asymmetric_qdq_fast_gelu.onnx";
+    clearFileIfExists(model_path);
+
+    model_builder::CreateAsymmetricQdqMatMulFastGeluModel(
+        model_path, "LoweredAsymmetricQdqFastGeluGraph");
+
+    Ort::SessionOptions session_options;
+    // FastGelu is intentionally kept on CPU so this test can validate a stable
+    // mixed-partition graph: the asymmetric Q/DQ + MatMul region on TRT-RTX and
+    // FastGelu on CPU.
+    AppendTrtRtxEp(session_options, {{"nv_op_types_to_exclude", "FastGelu"}});
+    const std::filesystem::path profile_prefix =
+        "ep_context_lowered_asymmetric_qdq_fast_gelu_profile";
+    session_options.EnableProfiling(toOrtString(profile_prefix).c_str());
+
+    Ort::Session session(*ort_env, toOrtString(model_path).c_str(), session_options);
+    Ort::RunOptions run_options;
+
+    const std::vector<int64_t> input_shape = {2, 3};
+    const std::vector<float> input_data = {
+        1.10f, -0.35f, 2.30f,
+       -1.70f,  0.40f, 0.95f};
+    const std::vector<float> expected_output =
+        ComputeExpectedLoweredAsymmetricQdqMatMulFastGeluOutput(input_data);
+
+    Ort::AllocatorWithDefaultOptions allocator;
+    Ort::Value input_tensor = Ort::Value::CreateTensor<float>(
+        allocator.GetInfo(), const_cast<float*>(input_data.data()),
+        input_data.size(), input_shape.data(), input_shape.size());
+    const char* input_names[] = {"X"};
+    const char* output_names[] = {"O"};
+
+    std::vector<Ort::Value> outputs;
+    ASSERT_NO_THROW(outputs = session.Run(run_options, input_names, &input_tensor,
+                                          1, output_names, 1));
+    ASSERT_EQ(outputs.size(), 1u);
+    ASSERT_TRUE(outputs[0].IsTensor());
+
+    const auto output_info = outputs[0].GetTensorTypeAndShapeInfo();
+    EXPECT_EQ(output_info.GetElementCount(), expected_output.size());
+    const float* output_data = outputs[0].GetTensorData<float>();
+    for (size_t i = 0; i < expected_output.size(); ++i) {
+        EXPECT_NEAR(output_data[i], expected_output[i], 1e-5f)
+            << "Mismatch at output index " << i;
+    }
+
+    auto profile_path_alloc = session.EndProfilingAllocated(allocator);
+    ASSERT_NE(profile_path_alloc.get(), nullptr);
+
+    const std::filesystem::path profile_path{profile_path_alloc.get()};
+    ASSERT_TRUE(std::filesystem::is_regular_file(profile_path))
+        << "Profiling output not found at: " << profile_path.string();
+
+    const std::string profile = readTextFile(profile_path);
+
+    EXPECT_NE(profile.find("FastGelu"), std::string::npos)
+        << "Expected FastGelu to appear in ORT profiling output";
+    EXPECT_NE(profile.find("CPUExecutionProvider"), std::string::npos)
+        << "Expected CPUExecutionProvider to appear in ORT profiling output";
+    EXPECT_NE(profile.find(kEpName), std::string::npos)
+        << "Expected NvTensorRTRTXExecutionProvider to appear in ORT profiling output";
+}
+
+// Validates the AOT compile/load path for the lowered asymmetric DQ split graph:
+//   * compiling with TRT-RTX produces a mixed model that preserves EPContext + FastGelu
+//   * loading the compiled model keeps the TRT-RTX / CPU split intact at runtime
+//   * the final output still matches the same CPU-side golden reference
+TEST(TensorRTRTXEpTest_EpContext,
+     CompileLoweredAsymmetricDqMatMulPreservesSplitGraphAndOutput) {
+    ASSERT_FALSE(get_trt_rtx_devices(*ort_env).empty())
+        << "No TRT RTX EP devices found.";
+
+    const std::string model_path =
+        "ep_context_compile_lowered_asymmetric_dq_fast_gelu.onnx";
+    const std::string compiled_model_path =
+        "ep_context_compile_lowered_asymmetric_dq_fast_gelu_ctx.onnx";
+    clearFileIfExists(model_path);
+    clearFileIfExists(compiled_model_path);
+
+    model_builder::CreateAsymmetricDqMatMulFastGeluModel(
+        model_path, "CompileLoweredAsymmetricDqFastGeluGraph");
+
+    Ort::SessionOptions compile_session_options;
+    AppendTrtRtxEp(compile_session_options,
+                   {{"nv_op_types_to_exclude", "FastGelu"}});
+
+    Ort::ModelCompilationOptions compile_opts(*ort_env, compile_session_options);
+    compile_opts.SetEpContextEmbedMode(true);
+    compile_opts.SetInputModelPath(toOrtString(model_path).c_str());
+    compile_opts.SetOutputModelPath(toOrtString(compiled_model_path).c_str());
+
+    ASSERT_TRUE(Ort::CompileModel(*ort_env, compile_opts).IsOK());
+    ASSERT_TRUE(std::filesystem::is_regular_file(compiled_model_path))
+        << "Compiled model not found at: " << compiled_model_path;
+
+    // The compiled ONNX should preserve the split shape we care about:
+    // one or more EPContext nodes for TRT-RTX-owned regions and a standalone
+    // FastGelu node left outside the TRT-RTX partition.
+    const onnx::ModelProto compiled_model = readOnnxModel(compiled_model_path);
+    EXPECT_GE(countNodesByOpType(compiled_model.graph(), "EPContext"), 1u)
+        << "Expected compiled model to contain at least one EPContext node.";
+    EXPECT_EQ(countNodesByOpType(compiled_model.graph(), "FastGelu", "com.microsoft"), 1u)
+        << "Expected compiled model to preserve FastGelu outside the TRT-RTX partition.";
+
+    Ort::SessionOptions load_session_options;
+    AppendTrtRtxEp(load_session_options, {{"nv_op_types_to_exclude", "FastGelu"}});
+    const std::filesystem::path profile_prefix =
+        "ep_context_compile_lowered_asymmetric_dq_fast_gelu_profile";
+    load_session_options.EnableProfiling(toOrtString(profile_prefix).c_str());
+
+    Ort::Session session(*ort_env, toOrtString(compiled_model_path).c_str(),
+                         load_session_options);
+    Ort::RunOptions run_options;
+
+    const std::vector<int64_t> input_shape = {2, 3};
+    const std::vector<float> input_data = {
+        1.0f, 2.0f, -1.0f,
+        0.5f, -0.25f, 3.0f};
+    const std::vector<float> expected_output =
+        ComputeExpectedLoweredAsymmetricDqMatMulFastGeluOutput(input_data);
+
+    Ort::AllocatorWithDefaultOptions allocator;
+    Ort::Value input_tensor = Ort::Value::CreateTensor<float>(
+        allocator.GetInfo(), const_cast<float*>(input_data.data()), input_data.size(),
+        input_shape.data(), input_shape.size());
+    const char* input_names[] = {"X"};
+    const char* output_names[] = {"O"};
+
+    std::vector<Ort::Value> outputs;
+    ASSERT_NO_THROW(outputs = session.Run(run_options, input_names, &input_tensor,
+                                          1, output_names, 1));
+    ASSERT_EQ(outputs.size(), 1u);
+    ASSERT_TRUE(outputs[0].IsTensor());
+
+    const auto output_info = outputs[0].GetTensorTypeAndShapeInfo();
+    EXPECT_EQ(output_info.GetElementCount(), expected_output.size());
+    const float* output_data = outputs[0].GetTensorData<float>();
+    for (size_t i = 0; i < expected_output.size(); ++i) {
+        EXPECT_NEAR(output_data[i], expected_output[i], 1e-5f)
+            << "Mismatch at output index " << i;
+    }
+
+    auto profile_path_alloc = session.EndProfilingAllocated(allocator);
+    ASSERT_NE(profile_path_alloc.get(), nullptr);
+
+    const std::filesystem::path profile_path{profile_path_alloc.get()};
+    ASSERT_TRUE(std::filesystem::is_regular_file(profile_path))
+        << "Profiling output not found at: " << profile_path.string();
+
+    const std::string profile = readTextFile(profile_path);
+    EXPECT_NE(profile.find("FastGelu"), std::string::npos)
+        << "Expected FastGelu to appear in ORT profiling output";
+    EXPECT_NE(profile.find("CPUExecutionProvider"), std::string::npos)
+        << "Expected CPUExecutionProvider to appear in ORT profiling output";
+    EXPECT_NE(profile.find(kEpName), std::string::npos)
+        << "Expected NvTensorRTRTXExecutionProvider to appear in ORT profiling output";
+}
+
+// =============================================================================
+// EPContext node "source" attribute tests
+//
+// Verifies that the TRT RTX EP:
+//   * skips EPContext nodes belonging to a foreign EP (e.g. OpenVINO),
+//   * skips EPContext nodes belonging to the classic TensorRT EP,
+//   * still claims EPContext nodes with no "source" attribute (backward compat).
+// =============================================================================
+
+TEST(TensorRTRTXEpTest_EpContext, EPContextNode_ForeignSourceSkipped) {
+    ASSERT_FALSE(get_trt_rtx_devices(*ort_env).empty());
+    const std::string model_path = "ep_context_foreign_source_nv.onnx";
+    model_builder::CreateSyntheticEPContextModel(
+        model_path, "OpenVINOExecutionProvider");
+
+    Ort::SessionOptions session_options;
+    AppendTrtRtxEp(session_options);
+
+    try {
+        Ort::Session session(*ort_env, toOrtString(model_path).c_str(),
+                             session_options);
+        FAIL()
+            << "Expected session creation to fail for EPContext node with foreign source";
+    } catch (const Ort::Exception& e) {
+        const std::string error_msg = e.what();
+        EXPECT_TRUE(error_msg.find("EPContext") != std::string::npos)
+            << "Error should mention EPContext. Actual: " << error_msg;
+    }
+
+    std::filesystem::remove(model_path);
+}
+
+TEST(TensorRTRTXEpTest_EpContext, EPContextNode_ClassicTrtSourceSkipped) {
+    ASSERT_FALSE(get_trt_rtx_devices(*ort_env).empty());
+    const std::string model_path = "ep_context_classic_trt_source_nv.onnx";
+    model_builder::CreateSyntheticEPContextModel(
+        model_path, "TensorrtExecutionProvider");
+
+    Ort::SessionOptions session_options;
+    AppendTrtRtxEp(session_options);
+
+    try {
+        Ort::Session session(*ort_env, toOrtString(model_path).c_str(),
+                             session_options);
+        FAIL()
+            << "Expected session creation to fail for EPContext node with classic TRT source";
+    } catch (const Ort::Exception& e) {
+        const std::string error_msg = e.what();
+        EXPECT_TRUE(error_msg.find("EPContext") != std::string::npos)
+            << "Error should mention EPContext. Actual: " << error_msg;
+    }
+
+    std::filesystem::remove(model_path);
+}
+
+TEST(TensorRTRTXEpTest_EpContext, EPContextNode_NoSourceAttribute_BackwardCompat) {
+    ASSERT_FALSE(get_trt_rtx_devices(*ort_env).empty());
+    const std::string model_path = "ep_context_no_source_nv.onnx";
+    model_builder::CreateSyntheticEPContextModel(
+        model_path, /*source_attr=*/"", /*include_source_attr=*/false);
+
+    Ort::SessionOptions session_options;
+    AppendTrtRtxEp(session_options);
+
+    try {
+        Ort::Session session(*ort_env, toOrtString(model_path).c_str(),
+                             session_options);
+        // If session creation succeeds, backward compatibility is working.
+    } catch (const Ort::Exception& e) {
+        const std::string error_msg = e.what();
+        // Failure must NOT be "not compatible with any execution provider",
+        // which would indicate the node was never claimed by the EP.
+        EXPECT_TRUE(error_msg.find("is not compatible with any execution provider")
+                    == std::string::npos)
+            << "Legacy EPContext node without source should still be claimed by EP. "
+            << "Error: " << error_msg;
+    }
+
+    std::filesystem::remove(model_path);
+}

--- a/tests/test_tensorrt_rtx_load_model.cpp
+++ b/tests/test_tensorrt_rtx_load_model.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <onnxruntime_cxx_api.h>
+
+#include <filesystem>
+#include <memory>
+
+#include "test_tensorrt_rtx_utils.h"
+
+extern std::unique_ptr<Ort::Env> ort_env;
+
+TEST(TensorRTRTXEpTest_LoadModel, ModelFileExists) {
+    ASSERT_TRUE(std::filesystem::is_regular_file(kModelPath))
+        << "Model not found at: " << kModelPath;
+}
+
+TEST(TensorRTRTXEpTest_LoadModel, CreatesSessionSuccessfully) {
+    ASSERT_TRUE(std::filesystem::is_regular_file(kModelPath))
+        << "Model not found at: " << kModelPath;
+
+    Ort::SessionOptions session_options;
+    Ort::KeyValuePairs ep_options;
+    const auto trt_rtx_devices = get_trt_rtx_devices(*ort_env);
+    session_options.AppendExecutionProvider_V2(*ort_env, trt_rtx_devices, ep_options);
+    Ort::Session session(*ort_env, toOrtString(kModelPath).c_str(), session_options);
+
+    EXPECT_EQ(session.GetInputCount(), 1);
+    EXPECT_EQ(session.GetOutputCount(), 1);
+}

--- a/tests/test_tensorrt_rtx_main.cpp
+++ b/tests/test_tensorrt_rtx_main.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <onnxruntime_cxx_api.h>
+#include "test_tensorrt_rtx_utils.h"
+
+#include <filesystem>
+#include <iostream>
+#include <memory>
+
+// Shared ORT environment for all tests.
+// A single Env instance is reused so EP registrations persist across tests.
+std::unique_ptr<Ort::Env> ort_env;
+std::filesystem::path g_ep_lib_path;
+
+// Resolve the EP library path.
+//
+// On Windows the EP DLL delay-loads TRT RTX DLLs at session-creation time.
+// Windows resolves delay-loaded dependencies relative to the loading DLL, so
+// we must load the EP from the test executable's directory (where all sibling
+// DLLs were copied) rather than from the original build output path.
+// EP_LIB_PATH (the build-output absolute path) is used only as a fallback.
+static std::filesystem::path resolve_ep_lib(const char* argv0) {
+    const std::filesystem::path build_path = EP_LIB_PATH;
+    const auto local_path =
+        std::filesystem::absolute(argv0).parent_path() / build_path.filename();
+    if (std::filesystem::is_regular_file(local_path)) {
+        return local_path;
+    }
+    return build_path;
+}
+
+static void register_ep(Ort::Env& env, const char* argv0) {
+    const auto ep_lib = resolve_ep_lib(argv0);
+    if (!std::filesystem::is_regular_file(ep_lib)) {
+        std::cerr << "[setup] EP library not found at " << ep_lib
+                  << " — tests requiring the EP will be skipped.\n";
+        return;
+    }
+
+#ifdef _WIN32
+    auto ep_lib_str = ep_lib.wstring();
+#else
+    auto ep_lib_str = ep_lib.string();
+#endif
+
+    try {
+        env.RegisterExecutionProviderLibrary(kEpName, ep_lib_str.c_str());
+        std::cout << "[setup] Registered TRT RTX EP from " << ep_lib << "\n";
+        g_ep_lib_path = ep_lib;
+    } catch (const Ort::Exception& ex) {
+        std::cerr << "[setup] Failed to register TRT RTX EP: " << ex.what()
+                  << " — tests requiring the EP will be skipped.\n";
+    }
+}
+
+int main(int argc, char** argv) {
+    ort_env = std::make_unique<Ort::Env>(ORT_LOGGING_LEVEL_WARNING, "trt_rtx_ep_tests");
+    register_ep(*ort_env, argv[0]);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_tensorrt_rtx_model_builder.h
+++ b/tests/test_tensorrt_rtx_model_builder.h
@@ -1,0 +1,907 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Header-only ONNX model builders using raw protobuf API.
+// No internal ORT headers — only onnx/onnx_pb.h.
+#pragma once
+
+#include <onnx/onnx_pb.h>
+
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace model_builder {
+
+// ---------------------------------------------------------------------------
+// Float32 -> IEEE 754 binary16 (FLOAT16) conversion.
+// Truncates mantissa; handles zero/inf/NaN. Subnormals flushed to zero.
+// ---------------------------------------------------------------------------
+inline uint16_t Float32ToFloat16(float f) {
+    uint32_t x;
+    std::memcpy(&x, &f, sizeof(x));
+    const uint32_t sign     = (x >> 16) & 0x8000u;
+    const int32_t  exp32    = static_cast<int32_t>((x >> 23) & 0xFFu);
+    const uint32_t mantissa = (x >> 13) & 0x3FFu;
+    if (exp32 == 0xFF) {
+        // Inf or NaN — preserve NaN mantissa at least partially.
+        const uint16_t m = ((x & 0x7FFFFFu) != 0u) ? 0x1u : 0u;
+        return static_cast<uint16_t>(sign | 0x7C00u | m);
+    }
+    const int32_t exp16 = exp32 - 127 + 15;
+    if (exp16 <= 0) return static_cast<uint16_t>(sign);
+    if (exp16 >= 31) return static_cast<uint16_t>(sign | 0x7C00u);
+    return static_cast<uint16_t>(sign | (static_cast<uint32_t>(exp16) << 10) | mantissa);
+}
+
+// ---------------------------------------------------------------------------
+// Protobuf helpers
+// ---------------------------------------------------------------------------
+
+// Add a ValueInfoProto (graph input or output) with optional shape.
+// dims={} means no shape (unknown). dim value -1 becomes a symbolic param.
+inline void AddValueInfo(
+    google::protobuf::RepeatedPtrField<onnx::ValueInfoProto>* list,
+    const std::string& name,
+    int32_t elem_type,
+    const std::vector<int>& dims) {
+    auto* vi = list->Add();
+    vi->set_name(name);
+    auto* tensor_type = vi->mutable_type()->mutable_tensor_type();
+    tensor_type->set_elem_type(elem_type);
+    if (!dims.empty()) {
+        auto* shape = tensor_type->mutable_shape();
+        int dyn_idx = 0;
+        for (int d : dims) {
+            auto* dim = shape->add_dim();
+            if (d == -1) {
+                dim->set_dim_param(name + "_dim_" + std::to_string(dyn_idx++));
+            } else {
+                dim->set_dim_value(d);
+            }
+        }
+    }
+}
+
+// Add a node to the graph.
+inline onnx::NodeProto* AddNode(
+    onnx::GraphProto* graph,
+    const std::string& name,
+    const std::string& op_type,
+    const std::vector<std::string>& inputs,
+    const std::vector<std::string>& outputs,
+    const std::string& domain = "") {
+    auto* node = graph->add_node();
+    node->set_name(name);
+    node->set_op_type(op_type);
+    if (!domain.empty()) node->set_domain(domain);
+    for (auto& in : inputs) node->add_input(in);
+    for (auto& out : outputs) node->add_output(out);
+    return node;
+}
+
+// Serialize model to file.
+inline void SaveModel(const onnx::ModelProto& model,
+                      const std::string& path) {
+    std::ofstream out(path, std::ios::binary);
+    if (!out.is_open()) {
+        throw std::runtime_error("Cannot open file for writing: " + path);
+    }
+    if (!model.SerializeToOstream(&out)) {
+        throw std::runtime_error("Failed to serialize model to: " + path);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CreateBaseModel
+// ---------------------------------------------------------------------------
+//
+// Builds a simple Add-chain model:
+//
+//   X  Y          inputs: X, Y, Z (shape=dims), S (scalar [1])
+//    \ /           output: O
+//  Z  Add
+//   \ /
+//    Add
+//     |
+//  [FastGelu]      (optional, com.microsoft domain)
+//     |
+//    Add  S
+//     \ /
+//      O
+//
+// Dynamic dims: -1 becomes a symbolic dim parameter.
+// dtype: one of onnx::TensorProto_DataType values (FLOAT, FLOAT16, etc.)
+//
+inline void CreateBaseModel(
+    const std::string& path,
+    const std::string& graph_name,
+    const std::vector<int>& dims,
+    bool add_fast_gelu = false,
+    int32_t dtype = onnx::TensorProto_DataType_FLOAT) {
+    onnx::ModelProto model;
+    model.set_ir_version(7);
+
+    auto* opset = model.add_opset_import();
+    opset->set_domain("");
+    opset->set_version(13);
+
+    if (add_fast_gelu) {
+        auto* ms_opset = model.add_opset_import();
+        ms_opset->set_domain("com.microsoft");
+        ms_opset->set_version(1);
+    }
+
+    auto* graph = model.mutable_graph();
+    graph->set_name(graph_name);
+
+    // Graph inputs
+    AddValueInfo(graph->mutable_input(), "X", dtype, dims);
+    AddValueInfo(graph->mutable_input(), "Y", dtype, dims);
+    AddValueInfo(graph->mutable_input(), "Z", dtype, dims);
+    AddValueInfo(graph->mutable_input(), "S", dtype, {1});
+
+    // Graph output (no shape = dynamic)
+    AddValueInfo(graph->mutable_output(), "O", dtype, {});
+
+    // node_1: Add(X, Y) -> node_1_out_1
+    AddNode(graph, "node_1", "Add", {"X", "Y"}, {"node_1_out_1"});
+
+    // node_2: Add(node_1_out_1, Z) -> node_2_out_1
+    AddNode(graph, "node_2", "Add", {"node_1_out_1", "Z"}, {"node_2_out_1"});
+
+    std::string last_output = "node_2_out_1";
+
+    if (add_fast_gelu) {
+        // node_3: FastGelu(node_2_out_1) -> node_3_out_1  (com.microsoft domain)
+        AddNode(graph, "node_3", "FastGelu", {"node_2_out_1"}, {"node_3_out_1"},
+                "com.microsoft");
+        last_output = "node_3_out_1";
+    }
+
+    // node_5: Add(last_output, S) -> O
+    AddNode(graph, "node_5", "Add", {last_output, "S"}, {"O"});
+
+    SaveModel(model, path);
+}
+
+// ---------------------------------------------------------------------------
+// CreateAsymmetricDqMatMulFastGeluModel
+// ---------------------------------------------------------------------------
+//
+// Builds a split-partition graph designed to validate two properties:
+//   1. A constant-weight asymmetric DequantizeLinear(zero_point != 0) is
+//      lowered/folded so the MatMul partition remains TRT-RTX compilable.
+//   2. FastGelu (com.microsoft domain) stays outside the TRT-RTX partition.
+//
+// Graph:
+//
+//   X (float[2,3]) --------------------------.
+//                                            v
+//   Wq (int8[3,2]) -- DQ(zp=3, scale=0.25) -> MatMul -> FastGelu -> O
+//
+// Expected compiled model shape:
+//   [EPContext] -> FastGelu
+//
+inline void CreateAsymmetricDqMatMulFastGeluModel(
+    const std::string& path,
+    const std::string& graph_name) {
+    onnx::ModelProto model;
+    model.set_ir_version(7);
+
+    auto* opset = model.add_opset_import();
+    opset->set_domain("");
+    opset->set_version(13);
+
+    auto* ms_opset = model.add_opset_import();
+    ms_opset->set_domain("com.microsoft");
+    ms_opset->set_version(1);
+
+    auto* graph = model.mutable_graph();
+    graph->set_name(graph_name);
+
+    constexpr int kRows = 2;
+    constexpr int kInner = 3;
+    constexpr int kCols = 2;
+
+    AddValueInfo(graph->mutable_input(), "X", onnx::TensorProto_DataType_FLOAT,
+                 {kRows, kInner});
+    AddValueInfo(graph->mutable_output(), "O", onnx::TensorProto_DataType_FLOAT,
+                 {kRows, kCols});
+    AddValueInfo(graph->mutable_value_info(), "dequantizedWeights",
+                 onnx::TensorProto_DataType_FLOAT, {kInner, kCols});
+    AddValueInfo(graph->mutable_value_info(), "matmulOutput",
+                 onnx::TensorProto_DataType_FLOAT, {kRows, kCols});
+
+    {
+        auto* t = graph->add_initializer();
+        t->set_name("Wq");
+        t->set_data_type(onnx::TensorProto_DataType_INT8);
+        t->add_dims(kInner);
+        t->add_dims(kCols);
+        const std::vector<int8_t> weights = {16, -8, 5, 12, -3, 9};
+        t->set_raw_data(weights.data(),
+                        static_cast<int>(weights.size() * sizeof(int8_t)));
+    }
+    {
+        auto* t = graph->add_initializer();
+        t->set_name("weightScale");
+        t->set_data_type(onnx::TensorProto_DataType_FLOAT);
+        t->add_dims(1);
+        t->add_float_data(0.25f);
+    }
+    {
+        auto* t = graph->add_initializer();
+        t->set_name("weightZeroPoint");
+        t->set_data_type(onnx::TensorProto_DataType_INT8);
+        t->add_dims(1);
+        const int8_t zero_point = 3;
+        t->set_raw_data(&zero_point, sizeof(zero_point));
+    }
+
+    AddNode(graph, "dq_weights", "DequantizeLinear",
+            {"Wq", "weightScale", "weightZeroPoint"},
+            {"dequantizedWeights"});
+    AddNode(graph, "matmul", "MatMul", {"X", "dequantizedWeights"},
+            {"matmulOutput"});
+    AddNode(graph, "fast_gelu", "FastGelu", {"matmulOutput"}, {"O"},
+            "com.microsoft");
+
+    SaveModel(model, path);
+}
+
+// ---------------------------------------------------------------------------
+// CreateAsymmetricQdqMatMulFastGeluModel
+// ---------------------------------------------------------------------------
+//
+// Builds a split-partition graph that exercises asymmetric Q + DQ lowering on
+// an activation path before a TRT-friendly MatMul, followed by FastGelu on CPU.
+//
+// Graph:
+//
+//   X (float[2,3]) -- Q(zp=5, scale=0.25) -- DQ(zp=5, scale=0.25) --.
+//                                                                    v
+//   W (float[3,2]) -----------------------------------------------> MatMul -> FastGelu -> O
+//
+// Expected compiled / runtime shape:
+//   [Q/DQ lowering + MatMul on TRT-RTX] -> FastGelu on CPU
+//
+inline void CreateAsymmetricQdqMatMulFastGeluModel(
+    const std::string& path,
+    const std::string& graph_name) {
+    onnx::ModelProto model;
+    model.set_ir_version(7);
+
+    auto* opset = model.add_opset_import();
+    opset->set_domain("");
+    opset->set_version(13);
+
+    auto* ms_opset = model.add_opset_import();
+    ms_opset->set_domain("com.microsoft");
+    ms_opset->set_version(1);
+
+    auto* graph = model.mutable_graph();
+    graph->set_name(graph_name);
+
+    constexpr int kRows = 2;
+    constexpr int kInner = 3;
+    constexpr int kCols = 2;
+
+    AddValueInfo(graph->mutable_input(), "X", onnx::TensorProto_DataType_FLOAT,
+                 {kRows, kInner});
+    AddValueInfo(graph->mutable_output(), "O", onnx::TensorProto_DataType_FLOAT,
+                 {kRows, kCols});
+    AddValueInfo(graph->mutable_value_info(), "quantizedX",
+                 onnx::TensorProto_DataType_INT8, {kRows, kInner});
+    AddValueInfo(graph->mutable_value_info(), "dequantizedX",
+                 onnx::TensorProto_DataType_FLOAT, {kRows, kInner});
+    AddValueInfo(graph->mutable_value_info(), "matmulOutput",
+                 onnx::TensorProto_DataType_FLOAT, {kRows, kCols});
+
+    {
+        auto* t = graph->add_initializer();
+        t->set_name("activationScale");
+        t->set_data_type(onnx::TensorProto_DataType_FLOAT);
+        t->add_dims(1);
+        t->add_float_data(0.25f);
+    }
+    {
+        auto* t = graph->add_initializer();
+        t->set_name("activationZeroPoint");
+        t->set_data_type(onnx::TensorProto_DataType_INT8);
+        t->add_dims(1);
+        const int8_t zero_point = 5;
+        t->set_raw_data(&zero_point, sizeof(zero_point));
+    }
+    {
+        auto* t = graph->add_initializer();
+        t->set_name("W");
+        t->set_data_type(onnx::TensorProto_DataType_FLOAT);
+        t->add_dims(kInner);
+        t->add_dims(kCols);
+        const std::vector<float> weights = {
+            1.25f, -0.75f,
+            0.50f,  2.00f,
+           -1.50f,  0.25f};
+        for (float w : weights) {
+            t->add_float_data(w);
+        }
+    }
+
+    AddNode(graph, "quantize_x", "QuantizeLinear",
+            {"X", "activationScale", "activationZeroPoint"},
+            {"quantizedX"});
+    AddNode(graph, "dequantize_x", "DequantizeLinear",
+            {"quantizedX", "activationScale", "activationZeroPoint"},
+            {"dequantizedX"});
+    AddNode(graph, "matmul", "MatMul", {"dequantizedX", "W"},
+            {"matmulOutput"});
+    AddNode(graph, "fast_gelu", "FastGelu", {"matmulOutput"}, {"O"},
+            "com.microsoft");
+
+    SaveModel(model, path);
+}
+
+// ---------------------------------------------------------------------------
+// CreateTopkAndMultipleGraphOutputsModel
+// ---------------------------------------------------------------------------
+//
+// C++ translation of testdata/topk_and_multiple_graph_outputs.py
+//
+// input: "input" [N] (float, dynamic dim)
+// outputs: "scores" (float), "Less_output_0" (bool),
+//          "Div_17_output_0" (int64), "labels" (int64)
+//
+inline void CreateTopkAndMultipleGraphOutputsModel(const std::string& path) {
+    onnx::ModelProto model;
+    model.set_ir_version(7);
+    auto* opset = model.add_opset_import();
+    opset->set_domain("");
+    opset->set_version(13);
+
+    auto* graph = model.mutable_graph();
+    graph->set_name("TopKGraph");
+
+    // Input: "input" with dynamic dim N
+    {
+        auto* vi = graph->mutable_input()->Add();
+        vi->set_name("input");
+        auto* tt = vi->mutable_type()->mutable_tensor_type();
+        tt->set_elem_type(onnx::TensorProto_DataType_FLOAT);
+        tt->mutable_shape()->add_dim()->set_dim_param("N");
+    }
+
+    // Initializers
+    {
+        // K = [300]
+        auto* k = graph->add_initializer();
+        k->set_name("K");
+        k->set_data_type(onnx::TensorProto_DataType_INT64);
+        k->add_dims(1);
+        k->add_int64_data(300);
+    }
+    {
+        // zero = 0 (scalar)
+        auto* z = graph->add_initializer();
+        z->set_name("zero");
+        z->set_data_type(onnx::TensorProto_DataType_INT64);
+        z->add_int64_data(0);
+    }
+    {
+        // twenty_six = 26 (scalar)
+        auto* ts = graph->add_initializer();
+        ts->set_name("twenty_six");
+        ts->set_data_type(onnx::TensorProto_DataType_INT64);
+        ts->add_int64_data(26);
+    }
+
+    // Nodes
+    AddNode(graph, "TopK", "TopK", {"input", "K"}, {"scores", "topk_indices"});
+    AddNode(graph, "Less", "Less", {"topk_indices", "zero"}, {"Less_output_0"});
+    AddNode(graph, "Div", "Div", {"topk_indices", "twenty_six"}, {"Div_17_output_0"});
+    AddNode(graph, "Mod", "Mod", {"topk_indices", "twenty_six"}, {"labels"});
+
+    // Outputs
+    {
+        auto* vi = graph->mutable_output()->Add();
+        vi->set_name("scores");
+        auto* tt = vi->mutable_type()->mutable_tensor_type();
+        tt->set_elem_type(onnx::TensorProto_DataType_FLOAT);
+        tt->mutable_shape()->add_dim()->set_dim_param("K");
+    }
+    {
+        auto* vi = graph->mutable_output()->Add();
+        vi->set_name("Less_output_0");
+        auto* tt = vi->mutable_type()->mutable_tensor_type();
+        tt->set_elem_type(onnx::TensorProto_DataType_BOOL);
+        tt->mutable_shape()->add_dim()->set_dim_param("K");
+    }
+    {
+        auto* vi = graph->mutable_output()->Add();
+        vi->set_name("Div_17_output_0");
+        auto* tt = vi->mutable_type()->mutable_tensor_type();
+        tt->set_elem_type(onnx::TensorProto_DataType_INT64);
+        tt->mutable_shape()->add_dim()->set_dim_param("K");
+    }
+    {
+        auto* vi = graph->mutable_output()->Add();
+        vi->set_name("labels");
+        auto* tt = vi->mutable_type()->mutable_tensor_type();
+        tt->set_elem_type(onnx::TensorProto_DataType_INT64);
+        tt->mutable_shape()->add_dim()->set_dim_param("K");
+    }
+
+    SaveModel(model, path);
+}
+
+// ---------------------------------------------------------------------------
+// CreateNodeOutputNotUsedModel
+// ---------------------------------------------------------------------------
+//
+// C++ translation of testdata/node_output_not_used.py
+//
+// inputs: "X" [3,2] (float), "W" [2,3] (float)
+// output: "Y" (float)
+// Dropout produces two outputs; the mask is unused.
+//
+inline void CreateNodeOutputNotUsedModel(const std::string& path) {
+    onnx::ModelProto model;
+    model.set_ir_version(7);
+    auto* opset = model.add_opset_import();
+    opset->set_domain("");
+    opset->set_version(13);
+
+    auto* graph = model.mutable_graph();
+    graph->set_name("DropoutMatMulGraph");
+
+    // Inputs
+    AddValueInfo(graph->mutable_input(), "X",
+                 onnx::TensorProto_DataType_FLOAT, {3, 2});
+    AddValueInfo(graph->mutable_input(), "W",
+                 onnx::TensorProto_DataType_FLOAT, {2, 3});
+
+    // Output
+    AddValueInfo(graph->mutable_output(), "Y",
+                 onnx::TensorProto_DataType_FLOAT, {3, 3});
+
+    // Dropout(X) -> dropout_out, dropout_mask  (mask unused)
+    AddNode(graph, "DropoutNode", "Dropout", {"X"}, {"dropout_out", "dropout_mask"});
+
+    // MatMul(dropout_out, W) -> Y
+    AddNode(graph, "MatMulNode", "MatMul", {"dropout_out", "W"}, {"Y"});
+
+    SaveModel(model, path);
+}
+
+// ---------------------------------------------------------------------------
+// CreateFP8CustomOpModel
+// ---------------------------------------------------------------------------
+//
+// Builds:
+//   X (FP16 [4,64]) -> TRT_FP8QuantizeLinear(trt domain) ->
+//   X_quantized (FP8E4M3FN) -> TRT_FP8DequantizeLinear(trt domain) -> Y (FP16)
+//
+// The scale is a FP16 initializer shared by both nodes.
+// The TRT RTX EP registers the "trt" domain custom ops at EP creation time;
+// the raw protobuf references them by name + domain without needing a schema.
+//
+inline void CreateFP8CustomOpModel(const std::string& path,
+                                   const std::string& graph_name) {
+    onnx::ModelProto model;
+    model.set_ir_version(7);
+    auto* onnx_opset = model.add_opset_import();
+    onnx_opset->set_domain("");
+    onnx_opset->set_version(19);
+    auto* trt_opset = model.add_opset_import();
+    trt_opset->set_domain("trt");
+    trt_opset->set_version(1);
+
+    auto* graph = model.mutable_graph();
+    graph->set_name(graph_name);
+
+    const std::vector<int> dims = {4, 64};
+    constexpr int32_t kFP16 = onnx::TensorProto_DataType_FLOAT16;
+    constexpr int32_t kFP8  = onnx::TensorProto_DataType_FLOAT8E4M3FN;
+
+    AddValueInfo(graph->mutable_input(),  "X", kFP16, dims);
+    AddValueInfo(graph->mutable_output(), "Y", kFP16, dims);
+
+    // scale (FP16 scalar, 0.0078125f)
+    {
+        auto* t = graph->add_initializer();
+        t->set_name("scale");
+        t->set_data_type(kFP16);
+        t->add_dims(1);
+        const uint16_t v = Float32ToFloat16(0.0078125f);
+        t->set_raw_data(&v, sizeof(v));
+    }
+
+    AddNode(graph, "trt_fp8_quantize_node",   "TRT_FP8QuantizeLinear",
+            {"X", "scale"}, {"X_quantized"}, "trt");
+    AddNode(graph, "trt_fp8_dequantize_node", "TRT_FP8DequantizeLinear",
+            {"X_quantized", "scale"}, {"Y"}, "trt");
+
+    // Intermediate value info for the FP8 tensor (helps some parsers).
+    {
+        auto* vi = graph->mutable_value_info()->Add();
+        vi->set_name("X_quantized");
+        auto* tt = vi->mutable_type()->mutable_tensor_type();
+        tt->set_elem_type(kFP8);
+        for (int d : dims) tt->mutable_shape()->add_dim()->set_dim_value(d);
+    }
+
+    SaveModel(model, path);
+}
+
+// ---------------------------------------------------------------------------
+// CreateFP4CustomOpModel
+// ---------------------------------------------------------------------------
+//
+// Builds:
+//   X (FP16 [64,64]) -> TRT_FP4DynamicQuantize(trt domain) ->
+//        X_quantized (FP4E2M1 [64,64]), X_scale (FP8E4M3FN [64,4])
+//   X_scale -> DequantizeLinear -> X_scale_dequantized (FP16 [64,4])
+//   X_quantized, X_scale_dequantized -> DequantizeLinear (axis=-1, block_size=16)
+//        -> X_dequantized (FP16 [64,64])
+//
+inline void CreateFP4CustomOpModel(const std::string& path,
+                                   const std::string& graph_name) {
+    onnx::ModelProto model;
+    model.set_ir_version(10);
+    auto* onnx_opset = model.add_opset_import();
+    onnx_opset->set_domain("");
+    onnx_opset->set_version(23);
+    auto* trt_opset = model.add_opset_import();
+    trt_opset->set_domain("trt");
+    trt_opset->set_version(1);
+
+    auto* graph = model.mutable_graph();
+    graph->set_name(graph_name);
+
+    constexpr int32_t kFP16 = onnx::TensorProto_DataType_FLOAT16;
+    constexpr int32_t kFP8  = onnx::TensorProto_DataType_FLOAT8E4M3FN;
+    constexpr int32_t kFP4  = onnx::TensorProto_DataType_FLOAT4E2M1;
+    const std::vector<int> input_dims  = {64, 64};
+    const std::vector<int> scale_dims  = {64, 4};
+
+    AddValueInfo(graph->mutable_input(),  "X",             kFP16, input_dims);
+    AddValueInfo(graph->mutable_output(), "X_dequantized", kFP16, input_dims);
+
+    // scale (FP16 scalar, 0.1234f)
+    {
+        auto* t = graph->add_initializer();
+        t->set_name("scale");
+        t->set_data_type(kFP16);
+        t->add_dims(1);
+        const uint16_t v = Float32ToFloat16(0.1234f);
+        t->set_raw_data(&v, sizeof(v));
+    }
+    // dequant_scale (FP16 scalar, 0.0625f)
+    {
+        auto* t = graph->add_initializer();
+        t->set_name("dequant_scale");
+        t->set_data_type(kFP16);
+        t->add_dims(1);
+        const uint16_t v = Float32ToFloat16(0.0625f);
+        t->set_raw_data(&v, sizeof(v));
+    }
+
+    // TRT_FP4DynamicQuantize(X, scale) -> X_quantized, X_scale
+    {
+        auto* node = AddNode(graph, "trt_fp4_dyn_quant",
+                             "TRT_FP4DynamicQuantize",
+                             {"X", "scale"},
+                             {"X_quantized", "X_scale"},
+                             "trt");
+
+        auto* a_axis = node->add_attribute();
+        a_axis->set_name("axis");
+        a_axis->set_type(onnx::AttributeProto_AttributeType_INT);
+        a_axis->set_i(-1);
+
+        auto* a_block = node->add_attribute();
+        a_block->set_name("block_size");
+        a_block->set_type(onnx::AttributeProto_AttributeType_INT);
+        a_block->set_i(16);
+
+        auto* a_stype = node->add_attribute();
+        a_stype->set_name("scale_type");
+        a_stype->set_type(onnx::AttributeProto_AttributeType_INT);
+        a_stype->set_i(17);
+    }
+
+    // DequantizeLinear(X_scale, dequant_scale) -> X_scale_dequantized
+    AddNode(graph, "dequantize_scale_node", "DequantizeLinear",
+            {"X_scale", "dequant_scale"}, {"X_scale_dequantized"});
+
+    // DequantizeLinear(X_quantized, X_scale_dequantized) -> X_dequantized
+    // (axis=-1, block_size=16)
+    {
+        auto* node = AddNode(graph, "dequantize_data_node", "DequantizeLinear",
+                             {"X_quantized", "X_scale_dequantized"},
+                             {"X_dequantized"});
+
+        auto* a_axis = node->add_attribute();
+        a_axis->set_name("axis");
+        a_axis->set_type(onnx::AttributeProto_AttributeType_INT);
+        a_axis->set_i(-1);
+
+        auto* a_block = node->add_attribute();
+        a_block->set_name("block_size");
+        a_block->set_type(onnx::AttributeProto_AttributeType_INT);
+        a_block->set_i(16);
+    }
+
+    // Intermediate value info (optional, but helpful for downstream tools).
+    auto add_vi = [&](const std::string& name, int32_t dtype,
+                      const std::vector<int>& shape) {
+        auto* vi = graph->mutable_value_info()->Add();
+        vi->set_name(name);
+        auto* tt = vi->mutable_type()->mutable_tensor_type();
+        tt->set_elem_type(dtype);
+        for (int d : shape) tt->mutable_shape()->add_dim()->set_dim_value(d);
+    };
+    add_vi("X_quantized",         kFP4,  input_dims);
+    add_vi("X_scale",             kFP8,  scale_dims);
+    add_vi("X_scale_dequantized", kFP16, scale_dims);
+
+    SaveModel(model, path);
+}
+
+// ---------------------------------------------------------------------------
+// CreateLargeModel
+// ---------------------------------------------------------------------------
+//
+// Builds a multi-layer MatMul chain with large FP16 weights stored as
+// external data. Designed to exercise the `SetInputModelFromBuffer` +
+// `AddExternalInitializersFromFilesInMemory` and
+// `SetOutputModelExternalInitializersFile` code paths.
+//
+// input: "X" [1, hidden]  (FP16)
+// output: "O" [1, hidden] (FP16)
+//
+// Size control: num_layers * hidden * hidden * 2 bytes.
+// Default: 8 layers of [1024,1024] FP16 weights ~= 16 MB of weights.
+//
+inline void CreateLargeModel(const std::string& model_path,
+                             const std::string& external_data_path,
+                             int num_layers = 8,
+                             int hidden     = 1024) {
+    // ---- 1. Build the weight data file ------------------------------------
+    // All per-layer weights are concatenated in a single binary file.
+    // Each weight is hidden*hidden FP16 values.
+    const size_t per_layer_elems = static_cast<size_t>(hidden) * hidden;
+    const size_t per_layer_bytes = per_layer_elems * sizeof(uint16_t);
+
+    std::ofstream data_out(external_data_path, std::ios::binary);
+    if (!data_out.is_open()) {
+        throw std::runtime_error(
+            "Cannot open external data file for writing: " + external_data_path);
+    }
+
+    // Deterministic pseudo-random fp16 values (small magnitude, bounded).
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<int> dist(0, 0x2800);  // small fp16 magnitudes
+
+    std::vector<uint16_t> buffer(per_layer_elems);
+    for (int l = 0; l < num_layers; ++l) {
+        for (auto& v : buffer) v = static_cast<uint16_t>(dist(rng));
+        data_out.write(reinterpret_cast<const char*>(buffer.data()),
+                       static_cast<std::streamsize>(per_layer_bytes));
+    }
+    if (!data_out.good()) {
+        throw std::runtime_error(
+            "Failed to write external data to: " + external_data_path);
+    }
+    data_out.close();
+
+    // ---- 2. Build the ONNX model protobuf ---------------------------------
+    onnx::ModelProto model;
+    model.set_ir_version(7);
+    auto* opset = model.add_opset_import();
+    opset->set_domain("");
+    opset->set_version(13);
+
+    auto* graph = model.mutable_graph();
+    graph->set_name("large_model");
+
+    constexpr int32_t kFP16 = onnx::TensorProto_DataType_FLOAT16;
+
+    AddValueInfo(graph->mutable_input(),  "X", kFP16, {1, hidden});
+    AddValueInfo(graph->mutable_output(), "O", kFP16, {1, hidden});
+
+    // Extract the filename (location inside ONNX must be a relative path).
+    std::string location = external_data_path;
+    {
+        const auto pos = location.find_last_of("/\\");
+        if (pos != std::string::npos) location = location.substr(pos + 1);
+    }
+
+    std::string prev = "X";
+    for (int l = 0; l < num_layers; ++l) {
+        const std::string w_name   = "W" + std::to_string(l);
+        const std::string mm_out   = "mm" + std::to_string(l);
+        const std::string relu_out = (l == num_layers - 1)
+                                         ? std::string("O")
+                                         : ("r" + std::to_string(l));
+
+        // Weight initializer — stored as external data.
+        auto* t = graph->add_initializer();
+        t->set_name(w_name);
+        t->set_data_type(kFP16);
+        t->add_dims(hidden);
+        t->add_dims(hidden);
+        t->set_data_location(onnx::TensorProto_DataLocation_EXTERNAL);
+        {
+            auto* e = t->add_external_data();
+            e->set_key("location");
+            e->set_value(location);
+        }
+        {
+            auto* e = t->add_external_data();
+            e->set_key("offset");
+            e->set_value(std::to_string(
+                static_cast<long long>(static_cast<size_t>(l) * per_layer_bytes)));
+        }
+        {
+            auto* e = t->add_external_data();
+            e->set_key("length");
+            e->set_value(std::to_string(static_cast<long long>(per_layer_bytes)));
+        }
+
+        // X @ W -> mm
+        AddNode(graph, "mm_" + std::to_string(l), "MatMul",
+                {prev, w_name}, {mm_out});
+        // Relu(mm) -> next
+        AddNode(graph, "relu_" + std::to_string(l), "Relu",
+                {mm_out}, {relu_out});
+        prev = relu_out;
+    }
+
+    SaveModel(model, model_path);
+}
+
+// ---------------------------------------------------------------------------
+// CreateSyntheticEPContextModel
+// ---------------------------------------------------------------------------
+//
+// Creates an ONNX model with a single EPContext node (com.microsoft domain)
+// with an optional "source" attribute. Used to test that the TRT RTX EP
+// correctly skips EPContext nodes whose source belongs to a different EP.
+//
+inline void CreateSyntheticEPContextModel(const std::string& model_path,
+                                          const std::string& source_attr,
+                                          bool include_source_attr = true) {
+    onnx::ModelProto model;
+    model.set_ir_version(7);
+    auto* onnx_opset = model.add_opset_import();
+    onnx_opset->set_domain("");
+    onnx_opset->set_version(11);
+    auto* ms_opset = model.add_opset_import();
+    ms_opset->set_domain("com.microsoft");
+    ms_opset->set_version(1);
+
+    auto* graph = model.mutable_graph();
+    graph->set_name("EPContextSourceTest");
+
+    AddValueInfo(graph->mutable_input(),  "input",
+                 onnx::TensorProto_DataType_FLOAT, {1, 3});
+    AddValueInfo(graph->mutable_output(), "output",
+                 onnx::TensorProto_DataType_FLOAT, {1, 3});
+
+    auto* node = AddNode(graph, "ep_context_node", "EPContext",
+                         {"input"}, {"output"}, "com.microsoft");
+
+    // embed_mode attribute
+    {
+        auto* a = node->add_attribute();
+        a->set_name("embed_mode");
+        a->set_type(onnx::AttributeProto_AttributeType_INT);
+        a->set_i(1);
+    }
+    // ep_cache_context attribute (dummy data)
+    {
+        auto* a = node->add_attribute();
+        a->set_name("ep_cache_context");
+        a->set_type(onnx::AttributeProto_AttributeType_STRING);
+        a->set_s("dummy_context_data");
+    }
+    // source attribute (optional)
+    if (include_source_attr) {
+        auto* a = node->add_attribute();
+        a->set_name("source");
+        a->set_type(onnx::AttributeProto_AttributeType_STRING);
+        a->set_s(source_attr);
+    }
+
+    SaveModel(model, model_path);
+}
+
+// ---------------------------------------------------------------------------
+// CreateLargeScratchModel
+// ---------------------------------------------------------------------------
+//
+// Builds an fp32 model whose TRT runtime workspace (getDeviceMemorySizeV2 /
+// updateDeviceMemorySizeForShapes) is dominated by a single large
+// intermediate tensor T1 of shape [1, M, M].
+//
+//     X  [1, M, K]                      (input,  ~ M*K*4 bytes)
+//       \
+//        MatMul ---- W1 [K, M]          (weight, ~ M*K*4 bytes, zero-filled)
+//       /
+//     T1 [1, M, M]                      <-- dominates TRT scratch (M*M*4 bytes)
+//       |
+//      Relu
+//       |
+//     T2 [1, M, M]                      (same shape as T1, also in scratch)
+//       \
+//        MatMul ---- W2 [M, K]          (weight, ~ M*K*4 bytes, zero-filled)
+//       /
+//      Y  [1, M, K]                     (output, ~ M*K*4 bytes)
+//
+// The Relu between the two MatMuls is crucial: it breaks the algebraic
+// identity `MatMul(MatMul(X, W1), W2) == MatMul(X, W1 @ W2)`, which would
+// otherwise let an aggressive optimizer constant-fold `W1 @ W2` into a tiny
+// [K, K] weight and skip materialising T1 entirely. With Relu in place, the
+// [1, M, M] intermediate must be computed -> TRT's scratch allocation scales
+// as O(M^2) as intended.
+//
+// Because K is small (16) and M is large, the weights and graph I/O stay
+// small (~ M*K*4 bytes each, so the on-disk model is only a few MB) while
+// T1 / T2 of size M*M*4 bytes dominate runtime scratch:
+//
+//     M = 16384 -> on-disk ~3 MB,   scratch ~ 1024 MB   (1 GB)
+//     M = 23170 -> on-disk ~3 MB,   scratch ~ 2048 MB   (2 GB)
+//     M = 32768 -> on-disk ~5 MB,   scratch ~ 4096 MB   (4 GB)
+//
+// Empirically on RTX 5090 the measured scratch is M*M*4 bytes plus a fixed
+// ~7 MB TRT overhead.
+//
+// The absolute scratch numbers depend on TRT algo selection and device
+// memory alignment; the unit tests print the observed cudaMemGetInfo delta
+// so the caller can tune M for their device.
+//
+inline void CreateLargeScratchModel(
+    const std::string& path,
+    int M,
+    int K = 16) {
+    onnx::ModelProto model;
+    model.set_ir_version(7);
+    auto* opset = model.add_opset_import();
+    opset->set_domain("");
+    opset->set_version(13);
+
+    auto* graph = model.mutable_graph();
+    graph->set_name("LargeScratchGraph");
+
+    AddValueInfo(graph->mutable_input(), "X",
+                 onnx::TensorProto_DataType_FLOAT, {1, M, K});
+    AddValueInfo(graph->mutable_output(), "Y",
+                 onnx::TensorProto_DataType_FLOAT, {1, M, K});
+
+    // Zero-filled weights: TRT only cares about shape/dtype at load time. We
+    // keep K small so each weight is only a few MB regardless of M.
+    auto add_weight = [&](const std::string& name, int d0, int d1) {
+        auto* init = graph->add_initializer();
+        init->set_name(name);
+        init->set_data_type(onnx::TensorProto_DataType_FLOAT);
+        init->add_dims(d0);
+        init->add_dims(d1);
+        const size_t num_bytes = static_cast<size_t>(d0) *
+                                 static_cast<size_t>(d1) * sizeof(float);
+        init->mutable_raw_data()->assign(num_bytes, '\0');
+    };
+    add_weight("W1", K, M);
+    add_weight("W2", M, K);
+
+    AddNode(graph, "matmul_1", "MatMul", {"X",  "W1"}, {"T1"});
+    AddNode(graph, "relu_1",   "Relu",   {"T1"},       {"T2"});
+    AddNode(graph, "matmul_2", "MatMul", {"T2", "W2"}, {"Y"});
+
+    SaveModel(model, path);
+}
+
+}  // namespace model_builder

--- a/tests/test_tensorrt_rtx_options.cpp
+++ b/tests/test_tensorrt_rtx_options.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ported from onnxruntime/test/providers/nv_tensorrt_rtx/nv_options_test.cc
+// Uses only public ORT SDK APIs.
+
+#include <gtest/gtest.h>
+#include <onnxruntime_cxx_api.h>
+#include <onnxruntime_session_options_config_keys.h>
+
+#include <filesystem>
+#include <string>
+
+#include "test_tensorrt_rtx_model_builder.h"
+#include "test_tensorrt_rtx_utils.h"
+
+extern std::unique_ptr<Ort::Env> ort_env;
+
+// Helper: append TRT RTX EP to session options.
+static void AppendTrtRtxEp(
+    Ort::SessionOptions& so,
+    const std::unordered_map<std::string, std::string>& options = {}) {
+    auto devices = get_trt_rtx_devices(*ort_env);
+    ASSERT_FALSE(devices.empty()) << "No TRT RTX EP devices found.";
+    Ort::KeyValuePairs kv_options;
+    for (auto& [k, v] : options) {
+        kv_options.Add(k.c_str(), v.c_str());
+    }
+    so.AppendExecutionProvider_V2(*ort_env, devices, kv_options);
+}
+
+static size_t countFilesInDirectory(const std::string& dir_path) {
+    return static_cast<size_t>(std::distance(
+        std::filesystem::directory_iterator(dir_path),
+        std::filesystem::directory_iterator{}));
+}
+
+TEST(TensorRTRTXEpTest_Options, RuntimeCaching) {
+    const std::string model_name = "nv_execution_provider_runtime_caching.onnx";
+    const std::string model_name_ctx = "nv_execution_provider_runtime_caching_ctx.onnx";
+    clearFileIfExists(model_name_ctx);
+
+    const std::string runtime_cache_dir = "./runtime_cache/";
+    if (std::filesystem::exists(runtime_cache_dir)) {
+        std::filesystem::remove_all(runtime_cache_dir);
+    }
+
+    model_builder::CreateBaseModel(model_name, "test", {1, 3, 2});
+
+    // AOT: compile with runtime cache enabled
+    {
+        Ort::SessionOptions so;
+        so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+        so.AddConfigEntry(kOrtSessionOptionEpContextFilePath,
+                          model_name_ctx.c_str());
+        AppendTrtRtxEp(so, {{"nv_runtime_cache_path", runtime_cache_dir}});
+        Ort::Session session(*ort_env, toOrtString(model_name).c_str(), so);
+
+        auto io_binding = generate_io_binding(session);
+        Ort::RunOptions run_options;
+        session.Run(run_options, io_binding);
+    }
+    // Cache dumped on session destruction
+    ASSERT_TRUE(std::filesystem::exists(runtime_cache_dir));
+    ASSERT_EQ(countFilesInDirectory(runtime_cache_dir), 1u);
+
+    // Use existing cache
+    {
+        Ort::SessionOptions so;
+        AppendTrtRtxEp(so, {{"nv_runtime_cache_path", runtime_cache_dir}});
+        Ort::Session session(*ort_env, toOrtString(model_name_ctx).c_str(), so);
+    }
+    ASSERT_EQ(countFilesInDirectory(runtime_cache_dir), 1u);
+
+    // Create new cache in different directory
+    {
+        const std::string new_cache_dir = "./runtime_cache_new/";
+        if (std::filesystem::exists(new_cache_dir)) {
+            std::filesystem::remove_all(new_cache_dir);
+        }
+
+        Ort::SessionOptions so;
+        AppendTrtRtxEp(so, {{"nv_runtime_cache_path", new_cache_dir}});
+        {
+            Ort::Session session(*ort_env, toOrtString(model_name_ctx).c_str(), so);
+        }
+        // Cache dumped on session destruction
+        ASSERT_TRUE(std::filesystem::exists(new_cache_dir));
+        ASSERT_EQ(countFilesInDirectory(new_cache_dir), 1u);
+    }
+}

--- a/tests/test_tensorrt_rtx_proto_preprocessing.cpp
+++ b/tests/test_tensorrt_rtx_proto_preprocessing.cpp
@@ -1,0 +1,1027 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <onnxruntime_cxx_api.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <memory>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "clip_bound_compatibility.h"
+#include "pooling_dilation_compatibility.h"
+#include "test_tensorrt_rtx_model_builder.h"
+#include "test_tensorrt_rtx_utils.h"
+#include "trt_proto_preprocessing.h"
+
+extern std::unique_ptr<Ort::Env> ort_env;
+
+namespace
+{
+
+constexpr int32_t kFp32 = onnx::TensorProto_DataType_FLOAT;
+constexpr int32_t kFp16 = onnx::TensorProto_DataType_FLOAT16;
+constexpr int32_t kInt32 = onnx::TensorProto_DataType_INT32;
+constexpr const char* kOriginalDocString = "42";
+
+onnx::ModelProto MakeModel(int64_t opset_version = 13)
+{
+    onnx::ModelProto model;
+    model.set_ir_version(7);
+
+    auto* opset = model.add_opset_import();
+    opset->set_domain("");
+    opset->set_version(opset_version);
+
+    model.mutable_graph()->set_name("preprocessing_test_graph");
+    return model;
+}
+
+void AddFloatScalarInitializer(onnx::GraphProto& graph, const std::string& name, int32_t data_type, float value)
+{
+    auto* tensor = graph.add_initializer();
+    tensor->set_name(name);
+    tensor->set_data_type(data_type);
+
+    if (data_type == kFp16)
+    {
+        const uint16_t bits = model_builder::Float32ToFloat16(value);
+        tensor->set_raw_data(&bits, sizeof(bits));
+    }
+    else
+    {
+        tensor->set_raw_data(&value, sizeof(value));
+    }
+}
+
+void AddFloatVectorInitializer(onnx::GraphProto& graph, const std::string& name, int32_t data_type,
+                               const std::vector<float>& values)
+{
+    auto* tensor = graph.add_initializer();
+    tensor->set_name(name);
+    tensor->set_data_type(data_type);
+    tensor->add_dims(static_cast<int64_t>(values.size()));
+
+    if (data_type == kFp16)
+    {
+        std::vector<uint16_t> bits;
+        bits.reserve(values.size());
+        for (const float value : values)
+        {
+            bits.push_back(model_builder::Float32ToFloat16(value));
+        }
+        tensor->set_raw_data(bits.data(), bits.size() * sizeof(uint16_t));
+    }
+    else
+    {
+        tensor->set_raw_data(values.data(), values.size() * sizeof(float));
+    }
+}
+
+void AddConstantNode(onnx::GraphProto& graph, const std::string& name, const std::string& output_name,
+                     int32_t data_type, float value)
+{
+    auto* tensor = new onnx::TensorProto();
+    tensor->set_name(output_name);
+    tensor->set_data_type(data_type);
+    if (data_type == kFp16)
+    {
+        const uint16_t bits = model_builder::Float32ToFloat16(value);
+        tensor->set_raw_data(&bits, sizeof(bits));
+    }
+    else
+    {
+        tensor->set_raw_data(&value, sizeof(value));
+    }
+
+    auto* node = model_builder::AddNode(&graph, name, "Constant", {}, {output_name});
+    auto* attr = node->add_attribute();
+    attr->set_name("value");
+    attr->set_type(onnx::AttributeProto_AttributeType_TENSOR);
+    attr->set_allocated_t(tensor);
+}
+
+void AddIntsAttribute(onnx::NodeProto& node, const std::string& name, const std::vector<int64_t>& values)
+{
+    auto* attr = node.add_attribute();
+    attr->set_name(name);
+    attr->set_type(onnx::AttributeProto_AttributeType_INTS);
+    for (const auto value : values)
+    {
+        attr->add_ints(value);
+    }
+}
+
+void AddFloatAttribute(onnx::NodeProto& node, const std::string& name, float value)
+{
+    auto* attr = node.add_attribute();
+    attr->set_name(name);
+    attr->set_type(onnx::AttributeProto_AttributeType_FLOAT);
+    attr->set_f(value);
+}
+
+void AddStringAttribute(onnx::NodeProto& node, const std::string& name, const std::string& value)
+{
+    auto* attr = node.add_attribute();
+    attr->set_name(name);
+    attr->set_type(onnx::AttributeProto_AttributeType_STRING);
+    attr->set_s(value);
+}
+
+onnx::ModelProto BuildClipModel(const std::vector<std::string>& clip_inputs, int32_t data_type = kFp32,
+                                const std::vector<int>& shape = {1, 3})
+{
+    auto model = MakeModel();
+    auto* graph = model.mutable_graph();
+    model_builder::AddValueInfo(graph->mutable_input(), "X", data_type, shape);
+    model_builder::AddValueInfo(graph->mutable_output(), "Y", data_type, shape);
+
+    auto* node = model_builder::AddNode(graph, "clip", "Clip", clip_inputs, {"Y"});
+    node->set_doc_string(kOriginalDocString);
+    return model;
+}
+
+onnx::ModelProto BuildLegacyClipModel()
+{
+    auto model = MakeModel(/*opset_version=*/6);
+    auto* graph = model.mutable_graph();
+    model_builder::AddValueInfo(graph->mutable_input(), "X", kFp32, {1, 3});
+    model_builder::AddValueInfo(graph->mutable_output(), "Y", kFp32, {1, 3});
+
+    auto* node = model_builder::AddNode(graph, "legacy_clip", "Clip", {"X"}, {"Y"});
+    AddFloatAttribute(*node, "min", -1.0f);
+    AddFloatAttribute(*node, "max", 1.0f);
+    node->set_doc_string(kOriginalDocString);
+    return model;
+}
+
+onnx::ModelProto BuildPoolModel(const std::string& op_type, int32_t data_type, const std::vector<int>& input_shape,
+                                const std::vector<int>& output_shape, const std::vector<int64_t>& kernel_shape,
+                                const std::vector<int64_t>& dilations, const std::vector<int64_t>& strides = {},
+                                const std::vector<int64_t>& pads = {}, const std::string& auto_pad = "",
+                                bool add_second_output = false)
+{
+    auto model = MakeModel(/*opset_version=*/22);
+    auto* graph = model.mutable_graph();
+    model_builder::AddValueInfo(graph->mutable_input(), "X", data_type, input_shape);
+    model_builder::AddValueInfo(graph->mutable_output(), "Y", data_type, output_shape);
+    if (add_second_output)
+    {
+        model_builder::AddValueInfo(graph->mutable_output(), "Indices", onnx::TensorProto_DataType_INT64,
+                                    output_shape);
+    }
+
+    std::vector<std::string> outputs = {"Y"};
+    if (add_second_output)
+    {
+        outputs.push_back("Indices");
+    }
+
+    auto* node = model_builder::AddNode(graph, "pool", op_type, {"X"}, outputs);
+    node->set_doc_string(kOriginalDocString);
+    AddIntsAttribute(*node, "kernel_shape", kernel_shape);
+    if (!dilations.empty())
+    {
+        AddIntsAttribute(*node, "dilations", dilations);
+    }
+    if (!strides.empty())
+    {
+        AddIntsAttribute(*node, "strides", strides);
+    }
+    if (!pads.empty())
+    {
+        AddIntsAttribute(*node, "pads", pads);
+    }
+    if (!auto_pad.empty())
+    {
+        AddStringAttribute(*node, "auto_pad", auto_pad);
+    }
+    return model;
+}
+
+size_t CountNodes(const onnx::GraphProto& graph, const std::string& op_type)
+{
+    size_t count = 0;
+    for (const auto& node : graph.node())
+    {
+        if (node.op_type() == op_type)
+        {
+            ++count;
+        }
+    }
+    return count;
+}
+
+const onnx::NodeProto* FindNodeByOutput(const onnx::GraphProto& graph, const std::string& output_name)
+{
+    for (const auto& node : graph.node())
+    {
+        if (std::find(node.output().begin(), node.output().end(), output_name) != node.output().end())
+        {
+            return &node;
+        }
+    }
+    return nullptr;
+}
+
+const onnx::TensorProto* FindInitializer(const onnx::GraphProto& graph, const std::string& name)
+{
+    for (const auto& initializer : graph.initializer())
+    {
+        if (initializer.name() == name)
+        {
+            return &initializer;
+        }
+    }
+    return nullptr;
+}
+
+std::vector<int64_t> ReadInt64Initializer(const onnx::GraphProto& graph, const std::string& name)
+{
+    const auto* tensor = FindInitializer(graph, name);
+    if (tensor == nullptr)
+    {
+        ADD_FAILURE() << "Missing initializer: " << name;
+        return {};
+    }
+
+    std::vector<int64_t> values;
+    if (tensor->has_raw_data())
+    {
+        const auto bytes = tensor->raw_data().size();
+        values.resize(bytes / sizeof(int64_t));
+        std::memcpy(values.data(), tensor->raw_data().data(), bytes);
+        return values;
+    }
+
+    values.assign(tensor->int64_data().begin(), tensor->int64_data().end());
+    return values;
+}
+
+void ExpectOutputNode(const onnx::ModelProto& model, const std::string& output_name, const std::string& op_type,
+                      const std::vector<std::string>& inputs)
+{
+    const auto* node = FindNodeByOutput(model.graph(), output_name);
+    ASSERT_NE(node, nullptr) << "Could not find producer for output " << output_name;
+    EXPECT_EQ(node->op_type(), op_type);
+    ASSERT_EQ(node->input_size(), static_cast<int>(inputs.size()));
+    for (int i = 0; i < node->input_size(); ++i)
+    {
+        EXPECT_EQ(node->input(i), inputs[static_cast<size_t>(i)]);
+    }
+    EXPECT_EQ(node->doc_string(), kOriginalDocString);
+}
+
+void ExpectNativeSingleNode(const onnx::ModelProto& model, const std::string& op_type)
+{
+    ASSERT_EQ(model.graph().node_size(), 1);
+    EXPECT_EQ(model.graph().node(0).op_type(), op_type);
+    EXPECT_EQ(model.graph().node(0).doc_string(), kOriginalDocString);
+}
+
+struct SliceSpatialParams
+{
+    int64_t start_h = 0;
+    int64_t start_w = 0;
+    int64_t end_h = 0;
+    int64_t end_w = 0;
+    int64_t step_h = 0;
+    int64_t step_w = 0;
+
+    bool operator<(const SliceSpatialParams& other) const
+    {
+        return std::tie(start_h, start_w, end_h, end_w, step_h, step_w) <
+               std::tie(other.start_h, other.start_w, other.end_h, other.end_w, other.step_h, other.step_w);
+    }
+};
+
+std::set<SliceSpatialParams> CollectSliceSpatialParams(const onnx::GraphProto& graph)
+{
+    std::set<SliceSpatialParams> params;
+    for (const auto& node : graph.node())
+    {
+        if (node.op_type() != "Slice")
+        {
+            continue;
+        }
+
+        if (node.input_size() < 5)
+        {
+            ADD_FAILURE() << "Slice node has too few inputs: " << node.name();
+            continue;
+        }
+        const auto starts = ReadInt64Initializer(graph, node.input(1));
+        const auto ends = ReadInt64Initializer(graph, node.input(2));
+        const auto steps = ReadInt64Initializer(graph, node.input(4));
+        if (starts.size() < 4 || ends.size() < 4 || steps.size() < 4)
+        {
+            ADD_FAILURE() << "Slice node has rank < 4 parameters: " << node.name();
+            continue;
+        }
+
+        params.insert({starts[2], starts[3], ends[2], ends[3], steps[2], steps[3]});
+    }
+    return params;
+}
+
+void ExpectPoolLowered(const onnx::ModelProto& model, bool is_average_pool, size_t tap_count)
+{
+    EXPECT_EQ(CountNodes(model.graph(), "Slice"), tap_count);
+    if (is_average_pool)
+    {
+        EXPECT_EQ(CountNodes(model.graph(), "Add"), tap_count - 1);
+        EXPECT_EQ(CountNodes(model.graph(), "Div"), 1u);
+    }
+    else
+    {
+        EXPECT_EQ(CountNodes(model.graph(), "Max"), tap_count - 1);
+    }
+
+    const auto* output_node = FindNodeByOutput(model.graph(), "Y");
+    ASSERT_NE(output_node, nullptr);
+    EXPECT_EQ(output_node->op_type(), is_average_pool ? "Div" : "Max");
+    EXPECT_GE(output_node->input_size(), 2);
+    EXPECT_EQ(output_node->doc_string(), kOriginalDocString);
+}
+
+void SaveModel(const onnx::ModelProto& model, const std::filesystem::path& path)
+{
+    model_builder::SaveModel(model, path.string());
+}
+
+onnx::ModelProto ReadModel(const std::filesystem::path& path)
+{
+    std::ifstream file(path, std::ios::binary);
+    if (!file.is_open())
+    {
+        throw std::runtime_error("Could not open ONNX model: " + path.string());
+    }
+
+    onnx::ModelProto model;
+    if (!model.ParseFromIstream(&file))
+    {
+        throw std::runtime_error("Failed to parse ONNX model: " + path.string());
+    }
+    return model;
+}
+
+void AppendTrtRtxEp(Ort::SessionOptions& session_options)
+{
+    const auto devices = get_trt_rtx_devices(*ort_env);
+    ASSERT_FALSE(devices.empty()) << "No TRT RTX EP devices found.";
+    Ort::KeyValuePairs ep_options;
+    session_options.AppendExecutionProvider_V2(*ort_env, devices, ep_options);
+}
+
+void CompileModelWithTrtRtx(const onnx::ModelProto& model, const std::string& model_name)
+{
+    const auto input_path = std::filesystem::path(model_name + ".onnx");
+    const auto output_path = std::filesystem::path(model_name + "_ctx.onnx");
+    clearFileIfExists(input_path);
+    clearFileIfExists(output_path);
+    SaveModel(model, input_path);
+
+    Ort::SessionOptions session_options;
+    AppendTrtRtxEp(session_options);
+
+    Ort::ModelCompilationOptions compile_options(*ort_env, session_options);
+    compile_options.SetEpContextEmbedMode(true);
+    compile_options.SetInputModelPath(toOrtString(input_path).c_str());
+    compile_options.SetOutputModelPath(toOrtString(output_path).c_str());
+
+    const auto status = Ort::CompileModel(*ort_env, compile_options);
+    ASSERT_TRUE(status.IsOK()) << status.GetErrorMessage();
+
+    const auto compiled_model = ReadModel(output_path);
+    EXPECT_GE(CountNodes(compiled_model.graph(), "EPContext"), 1u)
+        << "Expected the tiny compatibility model to be assigned to TRT-RTX.";
+}
+
+}  // namespace
+
+// Intent:
+// WebNN clamp with default options means neither side is bounded. Chromium can
+// encode that as ONNX Clip(X, -inf, +inf), but TRT-RTX rejects non-finite Clip
+// activation bounds.
+//
+//   Before: X -- Clip(min=-inf, max=+inf) --> Y
+//   After:  X -- Identity -----------------> Y
+//
+// This test mirrors the required WebNN clamp default-option failures across the
+// scalar/vector ranks and fp32/fp16 dtypes we saw in conformance.
+TEST(TensorRTRTXProtoPreprocessingTest, ClipExplicitMinusInfPlusInf_RewritesToIdentity)
+{
+    const std::vector<std::vector<int>> shapes = {{}, {3}, {1, 3}, {1, 1, 3}, {1, 1, 1, 3}, {1, 1, 1, 1, 3}};
+    for (const auto data_type : {kFp32, kFp16})
+    {
+        for (const auto& shape : shapes)
+        {
+            auto model = BuildClipModel({"X", "min", "max"}, data_type, shape);
+            AddFloatScalarInitializer(*model.mutable_graph(), "min", data_type, -std::numeric_limits<float>::infinity());
+            AddFloatScalarInitializer(*model.mutable_graph(), "max", data_type, std::numeric_limits<float>::infinity());
+
+            trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+            ExpectOutputNode(model, "Y", "Identity", {"X"});
+        }
+    }
+}
+
+// Intent:
+// WebNN clamp with only minValue is a lower-bound-only clamp. The +inf upper
+// bound is just an encoding detail that TRT-RTX cannot parse as Clip.
+//
+//   Before: X -- Clip(min=finite, max=+inf) --> Y
+//   After:  X -- Max(X, finite_min) ---------> Y
+//
+// The negative/zero/positive min cases line up with the conformance tests that
+// failed before the compatibility pass.
+TEST(TensorRTRTXProtoPreprocessingTest, ClipFiniteMinPlusInf_RewritesToMax)
+{
+    for (const auto data_type : {kFp32, kFp16})
+    {
+        for (const float min_value : {-2.0f, 0.0f, 1.0f})
+        {
+            auto model = BuildClipModel({"X", "min", "max"}, data_type);
+            AddFloatScalarInitializer(*model.mutable_graph(), "min", data_type, min_value);
+            AddFloatScalarInitializer(*model.mutable_graph(), "max", data_type, std::numeric_limits<float>::infinity());
+
+            trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+            ExpectOutputNode(model, "Y", "Max", {"X", "min"});
+        }
+    }
+}
+
+// Intent:
+// WebNN clamp with only maxValue is an upper-bound-only clamp. The -inf lower
+// bound is not real math we need TRT to execute; it only tells WebNN there is
+// no lower bound.
+//
+//   Before: X -- Clip(min=-inf, max=finite) --> Y
+//   After:  X -- Min(X, finite_max) ---------> Y
+//
+// The negative/zero/positive max cases mirror the required conformance
+// failures fixed by this pass.
+TEST(TensorRTRTXProtoPreprocessingTest, ClipMinusInfFiniteMax_RewritesToMin)
+{
+    for (const auto data_type : {kFp32, kFp16})
+    {
+        for (const float max_value : {-2.0f, 0.0f, 3.0f})
+        {
+            auto model = BuildClipModel({"X", "min", "max"}, data_type);
+            AddFloatScalarInitializer(*model.mutable_graph(), "min", data_type, -std::numeric_limits<float>::infinity());
+            AddFloatScalarInitializer(*model.mutable_graph(), "max", data_type, max_value);
+
+            trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+            ExpectOutputNode(model, "Y", "Min", {"X", "max"});
+        }
+    }
+}
+
+// Intent:
+// Finite Clip bounds are not the TRT-RTX limitation we are working around.
+// Keeping native Clip preserves the original graph shape and lets TRT parse the
+// compact operator when both activation parameters are finite.
+//
+//   X -- Clip(min=-1, max=1) --> Y
+//
+// This guards against the compatibility pass becoming an unnecessary generic
+// Clip decomposition pass.
+TEST(TensorRTRTXProtoPreprocessingTest, ClipFiniteMinFiniteMax_RemainsClip)
+{
+    auto model = BuildClipModel({"X", "min", "max"});
+    AddFloatScalarInitializer(*model.mutable_graph(), "min", kFp32, -1.0f);
+    AddFloatScalarInitializer(*model.mutable_graph(), "max", kFp32, 1.0f);
+
+    trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+    ExpectNativeSingleNode(model, "Clip");
+}
+
+// Intent:
+// ONNX explicitly defines Clip behavior when min > max: all inputs become max.
+// WebNN validation normally rejects an invalid range before graph execution, so
+// this is an ONNX-only semantic that our WebNN compatibility pass must not
+// accidentally change.
+//
+//   X -- Clip(min=3, max=1) --> Y
+//
+// Leaving this as Clip keeps the ONNX edge case intact.
+TEST(TensorRTRTXProtoPreprocessingTest, ClipFiniteMinGreaterThanFiniteMax_RemainsClip)
+{
+    auto model = BuildClipModel({"X", "min", "max"});
+    AddFloatScalarInitializer(*model.mutable_graph(), "min", kFp32, 3.0f);
+    AddFloatScalarInitializer(*model.mutable_graph(), "max", kFp32, 1.0f);
+
+    trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+    ExpectNativeSingleNode(model, "Clip");
+}
+
+// Intent:
+// Modern ONNX Clip allows optional min/max inputs to be omitted, but omitted
+// ONNX bounds default to finite numeric_limits values, not true infinities.
+//
+//   X -- Clip(missing min, missing max) --> Y
+//
+// If this became Identity, then X=[+inf] would incorrectly remain +inf instead
+// of being clamped to the finite dtype max. This test protects the P2 review
+// fix.
+TEST(TensorRTRTXProtoPreprocessingTest, ClipMissingBothBounds_RemainsClip)
+{
+    auto model = BuildClipModel({"X"});
+
+    trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+    ExpectNativeSingleNode(model, "Clip");
+}
+
+// Intent:
+// ONNX missing min is not equivalent to an explicit WebNN -inf lower bound.
+//
+//   X -- Clip(min omitted, max=finite) --> Y
+//
+// The pass must not rewrite this to Min unless it has proven that the lower
+// bound is an explicit -inf scalar.
+TEST(TensorRTRTXProtoPreprocessingTest, ClipMissingMinFiniteMax_RemainsClip)
+{
+    auto model = BuildClipModel({"X", "", "max"});
+    AddFloatScalarInitializer(*model.mutable_graph(), "max", kFp32, 1.0f);
+
+    trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+    ExpectNativeSingleNode(model, "Clip");
+}
+
+// Intent:
+// ONNX missing max is not equivalent to an explicit WebNN +inf upper bound.
+//
+//   X -- Clip(min=finite, max omitted) --> Y
+//
+// The pass must not rewrite this to Max unless the upper bound is an explicit
+// +inf scalar.
+TEST(TensorRTRTXProtoPreprocessingTest, ClipFiniteMinMissingMax_RemainsClip)
+{
+    auto model = BuildClipModel({"X", "min"});
+    AddFloatScalarInitializer(*model.mutable_graph(), "min", kFp32, -1.0f);
+
+    trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+    ExpectNativeSingleNode(model, "Clip");
+}
+
+// Intent:
+// Older ONNX Clip opsets encoded min/max as attributes and had only the data
+// input. Treating that one-input Clip as "both bounds missing" would silently
+// turn a finite clamp into Identity.
+//
+//   X -- Clip[min=-1,max=1] --> Y
+//
+// This protects the P1 legacy-Clip review finding.
+TEST(TensorRTRTXProtoPreprocessingTest, LegacyAttributeClip_RemainsClip)
+{
+    auto model = BuildLegacyClipModel();
+
+    trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+    ExpectNativeSingleNode(model, "Clip");
+}
+
+// Intent:
+// WebNN-generated bounds may appear as Constant nodes instead of initializers.
+// The pass intentionally recognizes scalar Constant producers, but does not
+// chase arbitrary arithmetic.
+//
+//   min_const -->.
+//                Clip --> Y       becomes       Max(X, min_const) --> Y
+//   max_const -->'
+//
+// This keeps the compatibility pass useful across common ONNX export styles.
+TEST(TensorRTRTXProtoPreprocessingTest, ClipConstantNodeInfBounds_Rewrites)
+{
+    auto model = BuildClipModel({"X", "min", "max"});
+    AddConstantNode(*model.mutable_graph(), "min_const", "min", kFp32, -1.0f);
+    AddConstantNode(*model.mutable_graph(), "max_const", "max", kFp32, std::numeric_limits<float>::infinity());
+
+    trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+    ExpectOutputNode(model, "Y", "Max", {"X", "min"});
+}
+
+// Intent:
+// Dynamic or vector bounds may carry runtime/user semantics. Rewriting them
+// would turn this parser-compatibility pass into partial constant propagation.
+//
+//   X, runtime_min, max=+inf -- Clip --> Y
+//   X, vector_min,  max=+inf -- Clip --> Y
+//
+// Both cases stay native so only provably scalar compile-time bounds are
+// rewritten.
+TEST(TensorRTRTXProtoPreprocessingTest, ClipDynamicOrVectorBounds_RemainsClip)
+{
+    {
+        auto model = BuildClipModel({"X", "runtime_min", "max"});
+        model_builder::AddValueInfo(model.mutable_graph()->mutable_input(), "runtime_min", kFp32, {});
+        AddFloatScalarInitializer(*model.mutable_graph(), "max", kFp32, std::numeric_limits<float>::infinity());
+
+        trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+        ExpectNativeSingleNode(model, "Clip");
+    }
+    {
+        auto model = BuildClipModel({"X", "vector_min", "max"});
+        AddFloatVectorInitializer(*model.mutable_graph(), "vector_min", kFp32, {-1.0f, -2.0f});
+        AddFloatScalarInitializer(*model.mutable_graph(), "max", kFp32, std::numeric_limits<float>::infinity());
+
+        trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+        ExpectNativeSingleNode(model, "Clip");
+    }
+}
+
+// Intent:
+// The pass removes only WebNN's explicit unbounded sides. It must not rewrite
+// cases that intentionally produce infinities or NaNs.
+//
+//   min=NaN, max=+inf
+//   min=+inf, max=+inf
+//   min=-inf, max=-inf
+//
+// These stay as Clip because replacing them with Identity/Min/Max would change
+// observable non-finite behavior.
+TEST(TensorRTRTXProtoPreprocessingTest, ClipNaNOrWrongInfinityDirection_RemainsClip)
+{
+    const std::vector<std::pair<float, float>> cases = {
+        {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::infinity()},
+        {std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity()},
+        {-std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity()},
+    };
+
+    for (const auto& [min_value, max_value] : cases)
+    {
+        auto model = BuildClipModel({"X", "min", "max"});
+        AddFloatScalarInitializer(*model.mutable_graph(), "min", kFp32, min_value);
+        AddFloatScalarInitializer(*model.mutable_graph(), "max", kFp32, max_value);
+
+        trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+        ExpectNativeSingleNode(model, "Clip");
+    }
+}
+
+// Intent:
+// The provider's proto-node bookkeeping uses stable logical outputs and ORT
+// doc_string node ids. A rewrite may change the operator, but it must not
+// change the original output edge or lose the doc string.
+//
+//   X -- Clip(min=-inf,max=+inf) -- "Y"
+//   X -- Identity -------------- -- "Y"
+//
+// This mirrors the mapping policy used by the Q/DQ lowering work.
+TEST(TensorRTRTXProtoPreprocessingTest, ClipRewritePreservesOutputNameAndDocString)
+{
+    auto model = BuildClipModel({"X", "min", "max"});
+    AddFloatScalarInitializer(*model.mutable_graph(), "min", kFp32, -std::numeric_limits<float>::infinity());
+    AddFloatScalarInitializer(*model.mutable_graph(), "max", kFp32, std::numeric_limits<float>::infinity());
+
+    trt_rtx_ep::RunClipBoundCompatibilityForTensorRt(model);
+
+    const auto* node = FindNodeByOutput(model.graph(), "Y");
+    ASSERT_NE(node, nullptr);
+    EXPECT_EQ(node->op_type(), "Identity");
+    EXPECT_EQ(node->output_size(), 1);
+    EXPECT_EQ(node->output(0), "Y");
+    EXPECT_EQ(node->doc_string(), kOriginalDocString);
+}
+
+// Intent:
+// WebNN averagePool2d with windowDimensions=[3,3] and dilations=[2,2] samples
+// nine real input positions spread across an effective 5x5 region:
+//
+//   x . x . x
+//   . . . . .
+//   x . x . x
+//   . . . . .
+//   x . x . x
+//
+// TRT-RTX rejects native pooling dilation, so the pass lowers each tap to a
+// Slice, adds all tap tensors, and divides by the tap count.
+TEST(TensorRTRTXProtoPreprocessingTest, AveragePoolDilated3x3Stride1_Fp32Fp16_Rewrites)
+{
+    for (const auto data_type : {kFp32, kFp16})
+    {
+        auto model = BuildPoolModel("AveragePool", data_type, {1, 2, 5, 5}, {1, 2, 1, 1}, {3, 3}, {2, 2});
+
+        trt_rtx_ep::RunPoolingDilationCompatibilityForTensorRt(model);
+
+        ExpectPoolLowered(model, /*is_average_pool=*/true, /*tap_count=*/9);
+        const auto params = CollectSliceSpatialParams(model.graph());
+        EXPECT_TRUE(params.count({0, 0, 1, 1, 1, 1}));
+        EXPECT_TRUE(params.count({4, 4, 5, 5, 1, 1}));
+    }
+}
+
+// Intent:
+// MaxPool has the same dilated tap selection as AveragePool, but combines taps
+// with elementwise Max instead of Add+Div.
+//
+//   tap0, tap1, ... tap8 -- Max chain --> Y
+//
+// This mirrors the required maxPool2d fp32/fp16 conformance failures.
+TEST(TensorRTRTXProtoPreprocessingTest, MaxPoolDilated3x3Stride1_Fp32Fp16_Rewrites)
+{
+    for (const auto data_type : {kFp32, kFp16})
+    {
+        auto model = BuildPoolModel("MaxPool", data_type, {1, 2, 5, 5}, {1, 2, 1, 1}, {3, 3}, {2, 2});
+
+        trt_rtx_ep::RunPoolingDilationCompatibilityForTensorRt(model);
+
+        ExpectPoolLowered(model, /*is_average_pool=*/false, /*tap_count=*/9);
+        const auto params = CollectSliceSpatialParams(model.graph());
+        EXPECT_TRUE(params.count({0, 0, 1, 1, 1, 1}));
+        EXPECT_TRUE(params.count({4, 4, 5, 5, 1, 1}));
+    }
+}
+
+// Intent:
+// Stride and dilation interact in the lowered Slice parameters. For output
+// coordinate o and tap coordinate k:
+//
+//   input_index = o * stride + k * dilation
+//
+// Therefore Slice uses start=k*dilation and step=stride. This catches the most
+// likely math bug if stride support regresses.
+TEST(TensorRTRTXProtoPreprocessingTest, PoolDilated3x3Stride2_RewritesSliceStepsCorrectly)
+{
+    auto model = BuildPoolModel("AveragePool", kFp32, {1, 1, 7, 7}, {1, 1, 2, 2}, {3, 3}, {2, 2}, {2, 2});
+
+    trt_rtx_ep::RunPoolingDilationCompatibilityForTensorRt(model);
+
+    ExpectPoolLowered(model, /*is_average_pool=*/true, /*tap_count=*/9);
+    const auto params = CollectSliceSpatialParams(model.graph());
+    EXPECT_TRUE(params.count({0, 0, 3, 3, 2, 2}));
+    EXPECT_TRUE(params.count({4, 4, 7, 7, 2, 2}));
+}
+
+// Intent:
+// Dilation is per spatial axis. A kernel=[2,3], dilations=[1,2] case makes
+// height and width offsets intentionally different:
+//
+//   x . x . x
+//   x . x . x
+//
+// This prevents an implementation that accidentally applies one dilation value
+// to every axis.
+TEST(TensorRTRTXProtoPreprocessingTest, PoolAsymmetricDilation_RewritesCorrectOffsets)
+{
+    auto model = BuildPoolModel("MaxPool", kFp32, {1, 1, 2, 5}, {1, 1, 1, 1}, {2, 3}, {1, 2});
+
+    trt_rtx_ep::RunPoolingDilationCompatibilityForTensorRt(model);
+
+    ExpectPoolLowered(model, /*is_average_pool=*/false, /*tap_count=*/6);
+    const auto params = CollectSliceSpatialParams(model.graph());
+    EXPECT_TRUE(params.count({0, 0, 1, 1, 1, 1}));
+    EXPECT_TRUE(params.count({1, 4, 2, 5, 1, 1}));
+}
+
+// Intent:
+// Unit dilation is already the native pooling case. Rewriting it would only
+// grow the graph and could interfere with TRT's normal pooling parser path.
+//
+//   X -- AveragePool(dilations=[1,1]) --> Y
+//
+// The compatibility pass should leave this untouched.
+TEST(TensorRTRTXProtoPreprocessingTest, PoolUnitDilation_RemainsNative)
+{
+    auto model = BuildPoolModel("AveragePool", kFp32, {1, 1, 5, 5}, {1, 1, 3, 3}, {3, 3}, {1, 1});
+
+    trt_rtx_ep::RunPoolingDilationCompatibilityForTensorRt(model);
+
+    ExpectNativeSingleNode(model, "AveragePool");
+}
+
+// Intent:
+// Padding changes which elements participate in edge windows. AveragePool also
+// needs count_include_pad-aware divisors. The current lowering deliberately
+// supports only the zero-padding/full-window subset.
+//
+//   X -- AveragePool(pads=[1,0,0,1], dilations=[2,2]) --> Y
+//
+// This must stay native until explicit mask/divisor support exists.
+TEST(TensorRTRTXProtoPreprocessingTest, PoolNonZeroPadding_RemainsNative)
+{
+    auto model = BuildPoolModel("AveragePool", kFp32, {1, 1, 5, 5}, {1, 1, 2, 2}, {3, 3}, {2, 2}, {}, {1, 0, 0, 1});
+
+    trt_rtx_ep::RunPoolingDilationCompatibilityForTensorRt(model);
+
+    ExpectNativeSingleNode(model, "AveragePool");
+}
+
+// Intent:
+// auto_pad modes synthesize padding and output sizing rules outside the simple
+// zero-pad equivalence we can prove with static Slice nodes.
+//
+//   X -- MaxPool(auto_pad=SAME_UPPER, dilations=[2,2]) --> Y
+//
+// The pass should not approximate this with the full-window lowering.
+TEST(TensorRTRTXProtoPreprocessingTest, PoolAutoPadSameOrValid_RemainsNative)
+{
+    for (const std::string auto_pad : {"SAME_UPPER", "VALID"})
+    {
+        auto model = BuildPoolModel("MaxPool", kFp32, {1, 1, 5, 5}, {1, 1, 1, 1}, {3, 3}, {2, 2}, {}, {}, auto_pad);
+
+        trt_rtx_ep::RunPoolingDilationCompatibilityForTensorRt(model);
+
+        ExpectNativeSingleNode(model, "MaxPool");
+    }
+}
+
+// Intent:
+// The lowering emits Slice nodes that read real input elements for every output
+// coordinate. If output metadata implies a partial final window, native pooling
+// needs padding/masking semantics that are outside this compatibility pass.
+//
+//   input 5x5, kernel 3x3, dilation 2, output claims 2x2
+//
+// The second output coordinate would read past the real input, so no rewrite.
+TEST(TensorRTRTXProtoPreprocessingTest, PoolCeilOrPartialWindow_RemainsNative)
+{
+    auto model = BuildPoolModel("AveragePool", kFp32, {1, 1, 5, 5}, {1, 1, 2, 2}, {3, 3}, {2, 2});
+
+    trt_rtx_ep::RunPoolingDilationCompatibilityForTensorRt(model);
+
+    ExpectNativeSingleNode(model, "AveragePool");
+}
+
+// Intent:
+// Static Slice starts/ends/steps cannot represent an unknown spatial dimension
+// without adding runtime Shape/Gather/arithmetic nodes. Dynamic-shape pooling
+// should therefore remain native for now.
+//
+//   X[N,C,H?,W] -- AveragePool(dilations=[2,2]) --> Y
+//
+// This protects against unsafe static assumptions.
+TEST(TensorRTRTXProtoPreprocessingTest, PoolDynamicShape_RemainsNative)
+{
+    auto model = BuildPoolModel("AveragePool", kFp32, {1, 1, -1, 5}, {1, 1, 1, 1}, {3, 3}, {2, 2});
+
+    trt_rtx_ep::RunPoolingDilationCompatibilityForTensorRt(model);
+
+    ExpectNativeSingleNode(model, "AveragePool");
+}
+
+// Intent:
+// The lowering currently supports fp32/fp16 because AveragePool emits a scalar
+// floating divisor and WebNN's failing required cases were float models.
+//
+//   int32 X -- AveragePool(dilations=[2,2]) --> Y
+//
+// Unsupported element types stay native rather than risking integer division
+// or type-promotion surprises.
+TEST(TensorRTRTXProtoPreprocessingTest, PoolUnsupportedType_RemainsNative)
+{
+    auto model = BuildPoolModel("AveragePool", kInt32, {1, 1, 5, 5}, {1, 1, 1, 1}, {3, 3}, {2, 2});
+
+    trt_rtx_ep::RunPoolingDilationCompatibilityForTensorRt(model);
+
+    ExpectNativeSingleNode(model, "AveragePool");
+}
+
+// Intent:
+// ONNX MaxPool can optionally produce indices as a second output. Our primitive
+// Max-chain lowering reproduces the pooled values only, not argmax indices.
+//
+//   X -- MaxPool(values, indices) --> Y, Indices
+//
+// This must stay native until an indices-compatible lowering is implemented.
+TEST(TensorRTRTXProtoPreprocessingTest, MaxPoolWithIndicesOutput_RemainsNative)
+{
+    auto model = BuildPoolModel("MaxPool", kFp32, {1, 1, 5, 5}, {1, 1, 1, 1}, {3, 3}, {2, 2}, {}, {},
+                                /*auto_pad=*/"", /*add_second_output=*/true);
+
+    trt_rtx_ep::RunPoolingDilationCompatibilityForTensorRt(model);
+
+    ExpectNativeSingleNode(model, "MaxPool");
+}
+
+// Intent:
+// Like the Clip rewrite, pooling dilation lowering must preserve the externally
+// visible output name and ORT doc_string node id. Helper nodes may be inserted,
+// but downstream edges should still consume the original "Y" value.
+//
+//   X -- AveragePool(dilated) --> Y
+//   X -- Slice/Add/Div -------> Y
+//
+// This keeps capability/build graph mapping stable.
+TEST(TensorRTRTXProtoPreprocessingTest, PoolRewritePreservesOutputNameAndDocString)
+{
+    auto model = BuildPoolModel("AveragePool", kFp32, {1, 2, 5, 5}, {1, 2, 1, 1}, {3, 3}, {2, 2});
+
+    trt_rtx_ep::RunPoolingDilationCompatibilityForTensorRt(model);
+
+    const auto* node = FindNodeByOutput(model.graph(), "Y");
+    ASSERT_NE(node, nullptr);
+    EXPECT_EQ(node->op_type(), "Div");
+    EXPECT_EQ(node->output_size(), 1);
+    EXPECT_EQ(node->output(0), "Y");
+    EXPECT_EQ(node->doc_string(), kOriginalDocString);
+}
+
+// Intent:
+// Direct pass tests can succeed even if the production wrapper stops calling a
+// pass. The EP uses RunTensorRtProtoPreprocessing before capability discovery
+// and engine build, so this wrapper-level test checks the real integration
+// point.
+//
+//   Clip(-inf,+inf) + AveragePool(dilated)
+//          |
+//          v
+//   Identity + Slice/Add/Div after wrapper preprocessing
+TEST(TensorRTRTXProtoPreprocessingTest, RunTensorRtProtoPreprocessing_AppliesClipAndPoolingPasses)
+{
+    auto model = MakeModel();
+    auto* graph = model.mutable_graph();
+    model_builder::AddValueInfo(graph->mutable_input(), "X", kFp32, {1, 1, 5, 5});
+    model_builder::AddValueInfo(graph->mutable_output(), "Y", kFp32, {1, 1, 1, 1});
+    model_builder::AddValueInfo(graph->mutable_value_info(), "clip_out", kFp32, {1, 1, 5, 5});
+    AddFloatScalarInitializer(*graph, "min", kFp32, -std::numeric_limits<float>::infinity());
+    AddFloatScalarInitializer(*graph, "max", kFp32, std::numeric_limits<float>::infinity());
+
+    auto* clip = model_builder::AddNode(graph, "clip", "Clip", {"X", "min", "max"}, {"clip_out"});
+    clip->set_doc_string("clip_doc");
+    auto* pool = model_builder::AddNode(graph, "pool", "AveragePool", {"clip_out"}, {"Y"});
+    pool->set_doc_string("pool_doc");
+    AddIntsAttribute(*pool, "kernel_shape", {3, 3});
+    AddIntsAttribute(*pool, "dilations", {2, 2});
+
+    trt_rtx_ep::RunTensorRtProtoPreprocessing(model);
+
+    const auto* clip_out = FindNodeByOutput(model.graph(), "clip_out");
+    ASSERT_NE(clip_out, nullptr);
+    EXPECT_EQ(clip_out->op_type(), "Identity");
+    EXPECT_EQ(CountNodes(model.graph(), "Slice"), 9u);
+    EXPECT_EQ(CountNodes(model.graph(), "Div"), 1u);
+}
+
+// Intent:
+// This is a tiny runtime smoke test for the original WebNN clamp/TRT issue. It
+// does not replace the proto policy tests above; it proves that the EP path
+// handed to TRT can compile models whose source graph still contains the
+// parser-hostile WebNN Clip encodings.
+//
+//   Clip(finite,+inf) and Clip(-inf,finite)
+//        wrapper preprocessing
+//   Max / Min
+//
+// The compiled model should contain an EPContext, which means TRT-RTX actually
+// accepted a partition after preprocessing.
+TEST(TensorRTRTXProtoPreprocessingTest, TrtCompile_WebNNClampMinOnlyAndMaxOnly_Succeeds)
+{
+    ASSERT_FALSE(get_trt_rtx_devices(*ort_env).empty()) << "No TRT RTX EP devices found.";
+
+    {
+        auto model = BuildClipModel({"X", "min", "max"});
+        AddFloatScalarInitializer(*model.mutable_graph(), "min", kFp32, -1.0f);
+        AddFloatScalarInitializer(*model.mutable_graph(), "max", kFp32, std::numeric_limits<float>::infinity());
+        CompileModelWithTrtRtx(model, "trt_compile_webnn_clamp_min_only");
+    }
+    {
+        auto model = BuildClipModel({"X", "min", "max"});
+        AddFloatScalarInitializer(*model.mutable_graph(), "min", kFp32, -std::numeric_limits<float>::infinity());
+        AddFloatScalarInitializer(*model.mutable_graph(), "max", kFp32, 1.0f);
+        CompileModelWithTrtRtx(model, "trt_compile_webnn_clamp_max_only");
+    }
+}
+
+// Intent:
+// This smoke test exercises the exact required WebNN pooling dilation shape
+// that failed before the lowering:
+//
+//   input=[1,2,5,5], window=[3,3], dilations=[2,2]
+//
+// The source model still contains native AveragePool/MaxPool dilation. Success
+// plus EPContext in the compiled output confirms that production preprocessing
+// lowered the graph before TRT-RTX parsed it.
+TEST(TensorRTRTXProtoPreprocessingTest, TrtCompile_WebNNDilatedAveragePoolAndMaxPool_Succeeds)
+{
+    ASSERT_FALSE(get_trt_rtx_devices(*ort_env).empty()) << "No TRT RTX EP devices found.";
+
+    CompileModelWithTrtRtx(
+        BuildPoolModel("AveragePool", kFp32, {1, 2, 5, 5}, {1, 2, 1, 1}, {3, 3}, {2, 2}),
+        "trt_compile_webnn_average_pool_dilation");
+    CompileModelWithTrtRtx(BuildPoolModel("MaxPool", kFp32, {1, 2, 5, 5}, {1, 2, 1, 1}, {3, 3}, {2, 2}),
+                           "trt_compile_webnn_max_pool_dilation");
+}

--- a/tests/test_tensorrt_rtx_shared_mempool.cpp
+++ b/tests/test_tensorrt_rtx_shared_mempool.cpp
@@ -1,0 +1,795 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// =============================================================================
+// CudaMempoolAllocator tests
+// =============================================================================
+//
+// These tests exercise the reachable public-API paths of
+// `trt_rtx_ep::CudaMempoolAllocator`:
+//
+//   Function                         | Covered by test(s)
+//   ---------------------------------|---------------------------------
+//   Create()                         | all
+//   ~CudaMempoolAllocator()          | Lifecycle, Env teardown
+//   DoAlloc() default-stream branch  | ScratchReuse_DefaultStream, Cohesion_*, Shrink
+//   DoAlloc() user-stream branch     | ScratchReuse_UserStream, MultiStream_*
+//   DoFree()                         | all
+//   Shrink() + MaybeRehashLocked()   | ShrinkViaRunOption_ReturnsMemory
+//   SyncAllKnownStreams_NoThrow()    | Lifecycle dtor
+//   stream_map_/alloc_map_ bookkeep. | MultiStream_*
+//
+// NOT exercised (noted as future work):
+//   - AllocImpl/FreeImpl/ReserveImpl/GetStatsImpl/InfoImpl/AllocOnStreamImpl:
+//       these OrtAllocator callbacks are wired on the mempool allocator, but
+//       the mempool is not returned from CreateAllocatorImpl (BFC arena is),
+//       so they are unreachable through the public ORT plugin API.
+//   - `cudaErrorInvalidResourceHandle` retry path in DoFree: would require
+//       destroying a user-owned stream while the session still holds pool
+//       allocations on it, which is unsafe to do from a unit test.
+//
+// Measurement methodology:
+//   All size assertions use `cudaDeviceSynchronize()` + `cudaMemGetInfo()`
+//   deltas. Tolerance is centralized in `kToleranceBytes` (512 MB).
+
+#include <gtest/gtest.h>
+#include <onnxruntime_cxx_api.h>
+#include <onnxruntime_run_options_config_keys.h>
+
+#include <cuda_runtime.h>
+
+#include <atomic>
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include "test_tensorrt_rtx_model_builder.h"
+#include "test_tensorrt_rtx_utils.h"
+
+extern std::unique_ptr<Ort::Env> ort_env;
+
+namespace
+{
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+// Tolerance for GPU-memory assertions. Chosen per the design spec (512 MB)
+// to cover CUDA internal housekeeping, BFC arena chunking for weights/IO,
+// and TRT algo-selection variability across runs.
+constexpr size_t kToleranceBytes = 512ull * 1024 * 1024;
+
+constexpr size_t kMB = 1024ull * 1024;
+constexpr size_t kGB = 1024ull * kMB;
+
+// Expected TRT scratch byte count for a large-scratch model with T1=[1,M,M].
+// TRT aligns pool allocations up to the next block (~32 MB granularity), so
+// the actual value is slightly larger than this lower bound; this is used
+// for assertion upper bounds.
+constexpr size_t ExpectedScratchBytes(int M) {
+    return static_cast<size_t>(M) * static_cast<size_t>(M) * sizeof(float);
+}
+
+// Saturating subtract for size_t. Used in assertions where the "measured"
+// value can legitimately fall *below* the baseline (e.g. after Shrink has
+// released memory that was carried over from previous tests in the same
+// shared Ort::Env). Plain `a - b` would underflow.
+constexpr size_t SatSub(size_t a, size_t b) noexcept {
+    return (a > b) ? (a - b) : 0;
+}
+
+// Per-model dims for the large-scratch synthetic model.
+// Intermediate tensor T1 is shape [1, M, M] fp32, so scratch ~= M*M*4 bytes
+// plus ~7 MB of fixed TRT overhead (empirically observed on RTX 5090).
+//
+//   kMDimSmall  = 16384  (2^14)              -> scratch ~ 1   GB
+//   kMDimMedium = 23170  (~= 16384 * sqrt(2)) -> scratch ~ 2   GB
+//   kMDimLarge  = 32768  (2^15)              -> scratch ~ 4   GB
+//
+// Weights stay ~2 MB each (K=16) regardless of M, so the on-disk ONNX models
+// remain a few MB. The Ascending cohesion test keeps 3 sessions alive and
+// the concurrent two-stream test holds 2 * medium_scratch simultaneously, so
+// the fixture enforces a `kMinFreeGpuBytes` preflight check (see SetUp) and
+// skips the suite on devices that do not meet it.
+//
+// Tuning: if the card is under memory pressure, scale all three down
+// proportionally so the relative deltas (and the 512 MB tolerance) remain
+// meaningful. Each test prints a `[mempool]` scoreboard line so the actual
+// GPU deltas are always visible.
+constexpr int kMDimSmall  = 16384;
+constexpr int kMDimMedium = 23170;
+constexpr int kMDimLarge  = 32768;
+
+// Minimum free GPU memory required by the suite. Derived from the worst-case
+// concurrent footprint: Ascending cohesion (~7 GB: small+medium+large scratch)
+// plus a safety margin for BFC chunking, TRT algo variability, and weights.
+constexpr size_t kMinFreeGpuBytes = 8ull * kGB;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+size_t gpu_used_bytes()
+{
+    CUDA_CHECK(cudaDeviceSynchronize());
+    size_t free_bytes = 0;
+    size_t total_bytes = 0;
+    CUDA_CHECK(cudaMemGetInfo(&free_bytes, &total_bytes));
+    return total_bytes - free_bytes;
+}
+
+void log_used(const char* label, size_t used, size_t baseline)
+{
+    const long long delta_mb =
+        static_cast<long long>(used) - static_cast<long long>(baseline);
+    std::printf("  [mempool] %-48s  used=%6zu MB  delta=%+6lld MB\n",
+                label, used / kMB, delta_mb / static_cast<long long>(kMB));
+    std::fflush(stdout);
+}
+
+void append_trt_rtx_ep(Ort::SessionOptions& so,
+                       const std::unordered_map<std::string, std::string>& opts = {})
+{
+    auto devices = get_trt_rtx_devices(*ort_env);
+    ASSERT_FALSE(devices.empty()) << "No TRT RTX EP devices found.";
+    Ort::KeyValuePairs kv;
+    for (auto& [k, v] : opts) kv.Add(k.c_str(), v.c_str());
+    so.AppendExecutionProvider_V2(*ort_env, devices, kv);
+}
+
+// Build an Ort::Session for the large-scratch model with optional user
+// compute stream (passed via provider options `has_user_compute_stream` +
+// `user_compute_stream`, see src/tensorrt_rtx_provider_options.h).
+std::unique_ptr<Ort::Session> create_session_for_model(
+    const std::string& model_path,
+    cudaStream_t user_stream = nullptr)
+{
+    Ort::SessionOptions so;
+    std::unordered_map<std::string, std::string> ep_opts;
+    if (user_stream != nullptr)
+    {
+        ep_opts["has_user_compute_stream"] = "1";
+        // The EP parses this as a stringified size_t and reinterpret_casts
+        // it back to the stream pointer (info.cc:54-60).
+        ep_opts["user_compute_stream"] =
+            std::to_string(reinterpret_cast<size_t>(user_stream));
+    }
+    append_trt_rtx_ep(so, ep_opts);
+    return std::make_unique<Ort::Session>(
+        *ort_env, toOrtString(model_path).c_str(), so);
+}
+
+// Build and run N inference iterations with zero-filled CPU inputs bound via
+// IoBinding. Outputs are discarded (only memory behavior is under test).
+void run_iterations(Ort::Session& session,
+                    Ort::RunOptions& run_opts,
+                    int iterations)
+{
+    Ort::AllocatorWithDefaultOptions alloc;
+    Ort::IoBinding io(session);
+
+    for (size_t i = 0; i < session.GetInputCount(); ++i)
+    {
+        auto name  = session.GetInputNameAllocated(i, alloc);
+        auto info  = session.GetInputTypeInfo(i).GetTensorTypeAndShapeInfo();
+        auto shape = info.GetShape();
+        for (auto& d : shape) { if (d == -1) d = 1; }
+        auto val = Ort::Value::CreateTensor(
+            alloc, shape.data(), shape.size(), info.GetElementType());
+        io.BindInput(name.get(), val);
+    }
+    for (size_t i = 0; i < session.GetOutputCount(); ++i)
+    {
+        auto name = session.GetOutputNameAllocated(i, alloc);
+        io.BindOutput(name.get(), alloc.GetInfo());
+    }
+
+    for (int i = 0; i < iterations; ++i)
+    {
+        session.Run(run_opts, io);
+    }
+}
+
+// Convenience: build-or-reuse a scratch-heavy model file on disk.
+// Reuses an existing file if present to speed up repeat invocations of the
+// test suite; call `force=true` if you change the builder.
+std::string make_scratch_model(int M, const char* tag, bool force = false)
+{
+    std::string path = std::string("nv_mempool_model_") + tag + "_M" +
+                       std::to_string(M) + ".onnx";
+    if (force || !std::filesystem::exists(path))
+    {
+        model_builder::CreateLargeScratchModel(path, M);
+    }
+    return path;
+}
+
+// =============================================================================
+// Test fixture
+// =============================================================================
+//
+// The class name becomes the GoogleTest test-suite name for every TEST_F
+// below, so this is intentionally named to match the suite-filter style used
+// elsewhere in the codebase (TensorRTRTXEpTest_LoadModel,
+// TensorRTRTXEpTest_MemoryTest, ...). You can run all tests in this file via:
+//
+//     .\unittests.exe --gtest_filter=TensorRTRTXEpTest_SharedMempool.*
+//
+class TensorRTRTXEpTest_SharedMempool : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // The mempool allocator wiring (factory-owned device_mempool_allocators,
+        // shrinkage via RunOption, user-compute-stream passing through provider
+        // options) is only guaranteed to work correctly on ORT 1.25 or above.
+        // Skip the whole suite on older runtimes rather than failing cryptically.
+        std::string ort_version;
+        if (!ort_runtime_at_least(1, 25, ort_version)) {
+            GTEST_SKIP() << "Skipping: ONNX Runtime " << ort_version
+                         << " is older than the 1.25 minimum required for "
+                         << "the CUDA mempool allocator tests.";
+        }
+
+        ASSERT_FALSE(get_trt_rtx_devices(*ort_env).empty())
+            << "No TRT RTX EP devices found.";
+
+        // Preflight free-memory check: the suite needs room for multiple
+        // large-scratch sessions alive concurrently (see kMDim* above).
+        size_t free_bytes = 0, total_bytes = 0;
+        CUDA_CHECK(cudaMemGetInfo(&free_bytes, &total_bytes));
+        if (free_bytes < kMinFreeGpuBytes) {
+            GTEST_SKIP() << "Skipping: only " << (free_bytes / kMB)
+                         << " MB free on device; suite requires at least "
+                         << (kMinFreeGpuBytes / kMB) << " MB.";
+        }
+
+        baseline_ = gpu_used_bytes();
+        std::printf("  [mempool] baseline used=%zu MB (free=%zu MB)\n",
+                    baseline_ / kMB, free_bytes / kMB);
+    }
+
+    void TearDown() override
+    {
+        // Give the driver a chance to settle between tests.
+        (void)cudaDeviceSynchronize();
+    }
+
+    size_t baseline_{0};
+};
+
+}  // namespace
+
+// =============================================================================
+// 1. Lifecycle: Create / ~CudaMempoolAllocator
+// =============================================================================
+//
+// Runs three full create->run->destroy cycles of the same session and
+// asserts that only the FIRST cycle grows the device footprint — subsequent
+// cycles must reuse the pool block the first cycle primed.
+//
+// Why not "after destruction, used == baseline"? The mempool is owned by the
+// EP factory and lives for the entire Ort::Env lifetime. Its release
+// threshold is set to UINT64_MAX so blocks are NOT returned to the OS on
+// cudaFreeAsync — that only happens via explicit Shrink() (test 6). This
+// is correct-by-design: keeping the block cached is the entire point of
+// the pool.
+//
+// Exercises:
+//   - CudaMempoolAllocator::Create (first session creation)
+//   - DoAlloc / DoFree across multiple lifetimes on the same pool
+//   - Pointer invalidation / re-handoff between sessions
+//   - Memory leak check: no unbounded growth across cycles
+//
+// ~CudaMempoolAllocator itself fires only at Env teardown (after all tests
+// finish), which is outside any single test's observable scope.
+TEST_F(TensorRTRTXEpTest_SharedMempool, Lifecycle_CreateAndDestroySession)
+{
+    const auto path = make_scratch_model(kMDimSmall, "small");
+
+    auto run_one_cycle = [&](const char* label) -> size_t {
+        {
+            auto session = create_session_for_model(path);
+            Ort::RunOptions ro;
+            run_iterations(*session, ro, /*iterations=*/3);
+        }
+        const size_t used = gpu_used_bytes();
+        log_used(label, used, baseline_);
+        return used;
+    };
+
+    const size_t used_after_cycle1 = run_one_cycle("after cycle 1 (prime pool)");
+    const size_t used_after_cycle2 = run_one_cycle("after cycle 2");
+    const size_t used_after_cycle3 = run_one_cycle("after cycle 3");
+
+    // Cycle 1 primes the pool: expect noticeable growth above baseline
+    // (the small model's scratch is ~1 GB). We sanity-check it grew rather
+    // than assert an exact number.
+    EXPECT_GT(used_after_cycle1, baseline_)
+        << "First cycle did not cause any GPU allocation — pool never primed.";
+
+    // The real invariant: cycles 2 and 3 must not grow the watermark beyond
+    // cycle 1 + kToleranceBytes. A leak on each create/destroy would push
+    // the watermark up by one scratch block per cycle.
+    const size_t growth_c2 = SatSub(used_after_cycle2, used_after_cycle1);
+    const size_t growth_c3 = SatSub(used_after_cycle3, used_after_cycle1);
+    std::printf("  [mempool] cycle2 growth=%zu MB  cycle3 growth=%zu MB\n",
+                growth_c2 / kMB, growth_c3 / kMB);
+
+    EXPECT_LE(used_after_cycle2, used_after_cycle1 + kToleranceBytes)
+        << "Second create/destroy cycle leaked more than "
+        << (kToleranceBytes / kMB) << " MB; pool is not being reused across "
+        << "session lifetimes.";
+    EXPECT_LE(used_after_cycle3, used_after_cycle1 + kToleranceBytes)
+        << "Third create/destroy cycle leaked more than "
+        << (kToleranceBytes / kMB) << " MB; pool is not being reused across "
+        << "session lifetimes.";
+}
+
+// =============================================================================
+// 2. Scratch reuse: same model, default stream
+// =============================================================================
+//
+// Confirms zero scratch reallocation when running the same network repeatedly
+// on a consistent CUDA stream.
+//
+// Exercises: DoAlloc (default-stream branch, stream==0), DoFree,
+// allocation/free bookkeeping on a single stream.
+TEST_F(TensorRTRTXEpTest_SharedMempool, ScratchReuse_SameModel_DefaultStream)
+{
+    const auto path = make_scratch_model(kMDimMedium, "medium");
+
+    auto session = create_session_for_model(path);
+    Ort::RunOptions run_opts;
+
+    // Warmup: first runs may allocate weights, JIT kernels, grow the pool.
+    run_iterations(*session, run_opts, /*iterations=*/3);
+    const size_t used_post_warmup = gpu_used_bytes();
+    log_used("after warmup (3 runs)", used_post_warmup, baseline_);
+
+    // Measurement: further runs should not grow the pool.
+    run_iterations(*session, run_opts, /*iterations=*/10);
+    const size_t used_post_measure = gpu_used_bytes();
+    log_used("after 10 measurement runs", used_post_measure, baseline_);
+
+    const size_t growth = (used_post_measure > used_post_warmup)
+                              ? used_post_measure - used_post_warmup
+                              : 0;
+    std::printf("  [mempool] scratch reallocation across 10 iters: %zu MB\n",
+                growth / kMB);
+
+    EXPECT_LE(growth, kToleranceBytes)
+        << "Scratch grew by more than " << (kToleranceBytes / kMB)
+        << " MB across 10 iterations of the same model on the same stream.";
+}
+
+// =============================================================================
+// 3. Scratch reuse: same model, user-provided compute stream
+// =============================================================================
+//
+// Same as #2 but the CUDA stream is created by the test and passed into the
+// session via provider options (`has_user_compute_stream` +
+// `user_compute_stream`). Exercises the non-default-stream allocation path
+// in DoAlloc (the `if (cuda_stream == 0)` branch is NOT taken).
+TEST_F(TensorRTRTXEpTest_SharedMempool, ScratchReuse_SameModel_UserComputeStream)
+{
+    cudaStream_t stream = nullptr;
+    CUDA_CHECK(cudaStreamCreate(&stream));
+
+    {
+        const auto path = make_scratch_model(kMDimMedium, "medium");
+        auto session = create_session_for_model(path, stream);
+
+        Ort::RunOptions run_opts;
+        run_iterations(*session, run_opts, /*iterations=*/3);
+        const size_t used_post_warmup = gpu_used_bytes();
+        log_used("after warmup (user stream)", used_post_warmup, baseline_);
+
+        run_iterations(*session, run_opts, /*iterations=*/10);
+        const size_t used_post_measure = gpu_used_bytes();
+        log_used("after 10 measure runs (user stream)",
+                 used_post_measure, baseline_);
+
+        const size_t growth = (used_post_measure > used_post_warmup)
+                                  ? used_post_measure - used_post_warmup
+                                  : 0;
+        EXPECT_LE(growth, kToleranceBytes)
+            << "Scratch grew by more than " << (kToleranceBytes / kMB)
+            << " MB across 10 iterations on a user-provided stream.";
+    }
+    // Session destroyed. Synchronize the stream before destroying it to let
+    // any queued cudaFreeAsync complete.
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+    CUDA_CHECK(cudaStreamDestroy(stream));
+}
+
+// =============================================================================
+// 4. Scratch cohesion: multiple sessions, ascending scratch
+// =============================================================================
+//
+// Creates & warms up three sessions in the SAME process with increasing
+// scratch requirements. The factory-owned mempool is shared across sessions,
+// so the peak device usage after all three should be bounded by:
+//
+//     baseline + weights/io_for_all_three + largest_scratch + tolerance
+//
+// rather than the naive sum small+med+large.
+//
+// We assert the stronger, spec-aligned bound:
+//     used_after_all_three <= used_after_largest_alone + kToleranceBytes.
+TEST_F(TensorRTRTXEpTest_SharedMempool, ScratchCohesion_MultiSession_Ascending)
+{
+    const auto path_small  = make_scratch_model(kMDimSmall,  "small");
+    const auto path_medium = make_scratch_model(kMDimMedium, "medium");
+    const auto path_large  = make_scratch_model(kMDimLarge,  "large");
+
+    // First: measure scratch for the large model alone.
+    size_t used_large_alone = 0;
+    {
+        auto session = create_session_for_model(path_large);
+        Ort::RunOptions run_opts;
+        run_iterations(*session, run_opts, /*iterations=*/2);
+        used_large_alone = gpu_used_bytes();
+        log_used("large-alone warmed", used_large_alone, baseline_);
+    }
+    // Session destroyed; allow pool to settle.
+    CUDA_CHECK(cudaDeviceSynchronize());
+    const size_t after_large_destroyed = gpu_used_bytes();
+    log_used("after large destroyed", after_large_destroyed, baseline_);
+
+    // Now ascending: small -> medium -> large, all alive concurrently.
+    auto s_small  = create_session_for_model(path_small);
+    Ort::RunOptions ro;
+    run_iterations(*s_small,  ro, 2);
+    log_used("after small warmup",  gpu_used_bytes(), baseline_);
+
+    auto s_medium = create_session_for_model(path_medium);
+    run_iterations(*s_medium, ro, 2);
+    log_used("after medium warmup", gpu_used_bytes(), baseline_);
+
+    auto s_large  = create_session_for_model(path_large);
+    run_iterations(*s_large,  ro, 2);
+    const size_t used_ascending_all = gpu_used_bytes();
+    log_used("after large warmup (3 sessions alive)",
+             used_ascending_all, baseline_);
+
+    // Spec: "Total allocated memory shall not exceed pure TensorRT runtime
+    // requirements by more than 10%". We enforce the stronger inequality that
+    // co-resident scratch does not exceed the single-largest scratch plus
+    // kToleranceBytes (which covers 3x weight/IO overhead + 10% slack).
+    EXPECT_LE(used_ascending_all,
+              used_large_alone + kToleranceBytes)
+        << "Ascending multi-session footprint exceeds single-largest by more "
+        << "than " << (kToleranceBytes / kMB) << " MB; scratch cohesion failed.";
+}
+
+// =============================================================================
+// 5. Scratch cohesion: multiple sessions, descending scratch
+// =============================================================================
+//
+// Same three sessions but in descending order (large -> medium -> small).
+// Because the mempool already holds a block large enough for any of them
+// after the first warmup, subsequent sessions must reuse that block without
+// growing the process footprint.
+//
+// We assert: GPU usage after medium and small warmups is within
+// kToleranceBytes of the usage observed right after the large session warmed
+// up (i.e. the watermark is flat).
+TEST_F(TensorRTRTXEpTest_SharedMempool, ScratchCohesion_MultiSession_Descending)
+{
+    const auto path_small  = make_scratch_model(kMDimSmall,  "small");
+    const auto path_medium = make_scratch_model(kMDimMedium, "medium");
+    const auto path_large  = make_scratch_model(kMDimLarge,  "large");
+
+    auto s_large  = create_session_for_model(path_large);
+    Ort::RunOptions ro;
+    run_iterations(*s_large, ro, 2);
+    const size_t used_after_large = gpu_used_bytes();
+    log_used("after large warmup", used_after_large, baseline_);
+
+    auto s_medium = create_session_for_model(path_medium);
+    run_iterations(*s_medium, ro, 2);
+    const size_t used_after_medium = gpu_used_bytes();
+    log_used("after medium warmup", used_after_medium, baseline_);
+
+    auto s_small  = create_session_for_model(path_small);
+    run_iterations(*s_small, ro, 2);
+    const size_t used_after_small = gpu_used_bytes();
+    log_used("after small warmup", used_after_small, baseline_);
+
+    // After the large session primes the pool, the medium/small sessions
+    // should not cause substantial growth — their scratch fits within the
+    // existing block.
+    const size_t growth_medium = (used_after_medium > used_after_large)
+                                     ? used_after_medium - used_after_large
+                                     : 0;
+    const size_t growth_small  = (used_after_small  > used_after_large)
+                                     ? used_after_small  - used_after_large
+                                     : 0;
+    std::printf("  [mempool] growth(medium)=%zu MB growth(small)=%zu MB\n",
+                growth_medium / kMB, growth_small / kMB);
+
+    EXPECT_LE(growth_medium, kToleranceBytes)
+        << "Adding medium session after large grew memory by more than "
+        << (kToleranceBytes / kMB) << " MB.";
+    EXPECT_LE(growth_small, kToleranceBytes)
+        << "Adding small session after large/medium grew memory by more than "
+        << (kToleranceBytes / kMB) << " MB.";
+}
+
+// =============================================================================
+// 6. Shrink via RunOption: memory returned to OS
+// =============================================================================
+//
+// Runs one session, captures the GPU used bytes, then runs once more with
+// `memory.enable_memory_arena_shrinkage = "gpu:0"`. The EP's OnRunEnd hook
+// should invoke `CudaMempoolAllocator::Shrink()` which calls
+// `cudaMemPoolTrimTo(pool, 0)`, returning idle pool memory to the OS.
+//
+// Exercises: Shrink() + MaybeRehashLocked().
+TEST_F(TensorRTRTXEpTest_SharedMempool, ShrinkViaRunOption_ReturnsMemory)
+{
+    const auto path = make_scratch_model(kMDimMedium, "medium");
+    auto session = create_session_for_model(path);
+
+    {
+        Ort::RunOptions ro;
+        run_iterations(*session, ro, 2);
+    }
+    const size_t used_before_shrink = gpu_used_bytes();
+    log_used("before shrink", used_before_shrink, baseline_);
+
+    {
+        Ort::RunOptions ro;
+        ro.AddConfigEntry(kOrtRunOptionsConfigEnableMemoryArenaShrinkage, "gpu:0");
+        // A single run with the shrinkage flag is enough: OnRunEnd triggers
+        // Shrink unconditionally when the target matches.
+        run_iterations(*session, ro, 1);
+    }
+    const size_t used_after_shrink = gpu_used_bytes();
+    log_used("after shrink", used_after_shrink, baseline_);
+
+    ASSERT_LE(used_after_shrink, used_before_shrink)
+        << "Shrink grew device memory instead of releasing it.";
+
+    const size_t released = SatSub(used_before_shrink, used_after_shrink);
+    std::printf("  [mempool] Shrink released %zu MB back to the OS\n",
+                released / kMB);
+
+    // Two semantic checks that together pin down "scratch was released":
+    //
+    //  a) Shrink must have freed at least ~one full scratch block — a no-op
+    //     Shrink (the bug we're guarding against) would release nothing.
+    //     We set the threshold to kMDimMedium^2*4 - kToleranceBytes so minor
+    //     pool-alignment slack is allowed.
+    //
+    //  b) Post-shrink watermark must not be MORE than kToleranceBytes above
+    //     baseline. Note: if a previous test primed the pool, `used_after_
+    //     shrink` can legitimately drop *below* baseline (case observed in
+    //     practice), so the comparison is written as `a <= b + tol` instead
+    //     of `a - b <= tol` to avoid size_t underflow.
+    const size_t kMinReleased = SatSub(
+        ExpectedScratchBytes(kMDimMedium), kToleranceBytes);
+    EXPECT_GE(released, kMinReleased)
+        << "Shrink only released " << (released / kMB) << " MB; expected at "
+        << "least " << (kMinReleased / kMB) << " MB (one scratch block).";
+
+    EXPECT_LE(used_after_shrink, baseline_ + kToleranceBytes)
+        << "After Shrink, GPU usage stayed more than "
+        << (kToleranceBytes / kMB) << " MB above baseline; scratch block was "
+        << "not released.";
+}
+
+// =============================================================================
+// 7. Multi-stream: two sessions on two threads, overlapping lifetimes
+// =============================================================================
+//
+// Two sessions are created, each with its own cuda stream passed via
+// provider options. Both run inference concurrently from two threads. This
+// exercises the multi-stream bookkeeping in CudaMempoolAllocator
+// (`stream_map_`) and `cudaMallocFromPoolAsync` on distinct streams.
+//
+// Because scratch blocks on the two streams overlap in time, the pool must
+// keep both alive, so the expected footprint is ~2 x medium_scratch. We
+// assert the peak is within kToleranceBytes of that upper bound, which also
+// verifies there is no double-counting or runaway growth.
+TEST_F(TensorRTRTXEpTest_SharedMempool, MultiStream_ConcurrentSessions_TwoThreads)
+{
+    const auto path = make_scratch_model(kMDimMedium, "medium");
+
+    cudaStream_t stream_a = nullptr;
+    cudaStream_t stream_b = nullptr;
+    CUDA_CHECK(cudaStreamCreate(&stream_a));
+    CUDA_CHECK(cudaStreamCreate(&stream_b));
+
+    size_t peak_used = 0;
+    std::atomic<bool> failed{false};
+    {
+        auto session_a = create_session_for_model(path, stream_a);
+        auto session_b = create_session_for_model(path, stream_b);
+
+        auto worker = [&](Ort::Session& s, std::atomic<bool>& err_flag) {
+            try {
+                Ort::RunOptions ro;
+                run_iterations(s, ro, /*iterations=*/4);
+            } catch (const std::exception& e) {
+                std::fprintf(stderr, "thread failed: %s\n", e.what());
+                err_flag.store(true);
+            }
+        };
+
+        std::thread ta(worker, std::ref(*session_a), std::ref(failed));
+        std::thread tb(worker, std::ref(*session_b), std::ref(failed));
+        ta.join();
+        tb.join();
+
+        peak_used = gpu_used_bytes();
+        log_used("after concurrent runs (2 streams)", peak_used, baseline_);
+    }
+    CUDA_CHECK(cudaStreamSynchronize(stream_a));
+    CUDA_CHECK(cudaStreamSynchronize(stream_b));
+    CUDA_CHECK(cudaStreamDestroy(stream_a));
+    CUDA_CHECK(cudaStreamDestroy(stream_b));
+
+    EXPECT_FALSE(failed.load()) << "At least one worker thread threw.";
+
+    // Upper bound: each stream holds its own scratch block simultaneously, so
+    // pool must reserve 2x the per-session scratch size. We derive the per-
+    // session scratch analytically from the model dims (T1=[1,M,M] fp32)
+    // rather than measuring it at runtime -- a runtime measurement done by
+    // creating a single session would be contaminated by pool warm-up from
+    // earlier tests (the existing pool block would already satisfy the new
+    // session's scratch demand, yielding a near-zero cudaMemGetInfo delta).
+    //
+    // The expected growth-from-baseline is therefore:
+    //     2 * per_session_scratch + kToleranceBytes
+    // covering pool alignment, a second weights copy, and BFC arena slack.
+    const size_t per_session = ExpectedScratchBytes(kMDimMedium);
+    const size_t upper_bound = baseline_ + 2 * per_session + kToleranceBytes;
+    std::printf("  [mempool] peak=%zu MB  upper_bound=%zu MB  "
+                "(per_session~%zu MB)\n",
+                peak_used / kMB, upper_bound / kMB, per_session / kMB);
+    EXPECT_LE(peak_used, upper_bound)
+        << "Concurrent two-stream usage exceeded 2x per-session scratch "
+        << "by more than " << (kToleranceBytes / kMB) << " MB.";
+}
+
+// =============================================================================
+// 8. Multi-stream: two sessions sequentially (non-overlapping), pool reuse
+// =============================================================================
+//
+// Same two sessions/streams, but used sequentially so that the first
+// session's scratch is returned to the pool before the second session
+// starts. The pool should reuse the same underlying block across the two
+// streams, so the footprint should look like 1 x medium scratch, not 2x.
+//
+// Exercises the same multi-stream code paths as test 7 but validates the
+// cohesion benefit when lifetimes do not overlap.
+TEST_F(TensorRTRTXEpTest_SharedMempool, MultiStream_SequentialSessions_PoolReuse)
+{
+    const auto path = make_scratch_model(kMDimMedium, "medium");
+
+    cudaStream_t stream_a = nullptr;
+    cudaStream_t stream_b = nullptr;
+    CUDA_CHECK(cudaStreamCreate(&stream_a));
+    CUDA_CHECK(cudaStreamCreate(&stream_b));
+
+    size_t used_after_first = 0;
+    size_t used_after_second = 0;
+
+    {
+        auto session_a = create_session_for_model(path, stream_a);
+        Ort::RunOptions ro;
+        run_iterations(*session_a, ro, 2);
+        used_after_first = gpu_used_bytes();
+        log_used("after first session (stream A)", used_after_first, baseline_);
+    }
+    CUDA_CHECK(cudaStreamSynchronize(stream_a));
+    const size_t after_first_destroyed = gpu_used_bytes();
+    log_used("after stream-A session destroyed",
+             after_first_destroyed, baseline_);
+
+    {
+        auto session_b = create_session_for_model(path, stream_b);
+        Ort::RunOptions ro;
+        run_iterations(*session_b, ro, 2);
+        used_after_second = gpu_used_bytes();
+        log_used("after second session (stream B)", used_after_second, baseline_);
+    }
+    CUDA_CHECK(cudaStreamSynchronize(stream_b));
+    CUDA_CHECK(cudaStreamDestroy(stream_a));
+    CUDA_CHECK(cudaStreamDestroy(stream_b));
+
+    // The second session's peak should be within tolerance of the first
+    // session's peak — both should fit in the same reused pool block.
+    const size_t growth = (used_after_second > used_after_first)
+                              ? used_after_second - used_after_first
+                              : 0;
+    std::printf("  [mempool] cross-stream reuse growth: %zu MB\n",
+                growth / kMB);
+    EXPECT_LE(growth, kToleranceBytes)
+        << "Sequential two-stream usage grew the pool by more than "
+        << (kToleranceBytes / kMB) << " MB; pool did not reuse block across "
+        << "streams.";
+}
+
+// =============================================================================
+// 9. Arena-shrinkage comparison (real-world model, CUDA graph on)
+// =============================================================================
+//
+// End-to-end sanity check using the real ResNet-18 model (kModelPath) with
+// `enable_cuda_graph=1`. Compares device-wide `cudaMemGetInfo` usage with
+// default RunOptions vs. RunOptions that request per-run arena shrinkage via
+// `kOrtRunOptionsConfigEnableMemoryArenaShrinkage`. This is an observation-
+// only scenario test (it prints the memory scoreboard for both scenarios for
+// manual comparison); no strict assertions are made because the tiny ResNet
+// scratch is dominated by CUDA-graph / weights overhead and numeric limits
+// are noisy. The explicit scratch-size assertions live in tests 1-8 above.
+TEST_F(TensorRTRTXEpTest_SharedMempool, ArenaShrinkageComparison)
+{
+    ASSERT_TRUE(std::filesystem::is_regular_file(kModelPath))
+        << "Model not found at: " << kModelPath;
+
+    constexpr int kWarmupRuns  = 3;
+    constexpr int kMeasureRuns = 5;
+
+    // Sessions in this test need CUDA graph capture enabled -- the mempool
+    // allocator must return stable pointers across iterations for capture to
+    // succeed, so this also implicitly smoke-tests pointer stability.
+    auto make_cuda_graph_session = []() {
+        Ort::SessionOptions so;
+        std::unordered_map<std::string, std::string> ep_opts;
+        ep_opts["enable_cuda_graph"] = "1";
+        append_trt_rtx_ep(so, ep_opts);
+        return std::make_unique<Ort::Session>(
+            *ort_env, toOrtString(kModelPath).c_str(), so);
+    };
+
+    // -------------------------------------------------------------------------
+    // Scenario A: default RunOptions (no memory arena shrinkage)
+    // -------------------------------------------------------------------------
+    std::puts("\n--- Scenario A: default RunOptions (no arena shrinkage) ---");
+    log_used("before session creation", gpu_used_bytes(), baseline_);
+    {
+        auto session = make_cuda_graph_session();
+        log_used("after session creation", gpu_used_bytes(), baseline_);
+
+        Ort::RunOptions run_opts_default;
+        run_iterations(*session, run_opts_default, kWarmupRuns);
+        log_used("after warmup runs (A)", gpu_used_bytes(), baseline_);
+
+        run_iterations(*session, run_opts_default, kMeasureRuns);
+        log_used("after measure runs (A)", gpu_used_bytes(), baseline_);
+    }
+    log_used("after session destruction (A)", gpu_used_bytes(), baseline_);
+
+    // -------------------------------------------------------------------------
+    // Scenario B: arena shrinkage enabled on gpu:0
+    // -------------------------------------------------------------------------
+    std::puts("\n--- Scenario B: arena shrinkage enabled (gpu:0) ---");
+    log_used("before session creation", gpu_used_bytes(), baseline_);
+    {
+        auto session = make_cuda_graph_session();
+        log_used("after session creation", gpu_used_bytes(), baseline_);
+
+        Ort::RunOptions run_opts_shrink;
+        run_opts_shrink.AddConfigEntry(
+            kOrtRunOptionsConfigEnableMemoryArenaShrinkage, "gpu:0");
+        run_iterations(*session, run_opts_shrink, kWarmupRuns);
+        log_used("after warmup runs (B)", gpu_used_bytes(), baseline_);
+
+        run_iterations(*session, run_opts_shrink, kMeasureRuns);
+        log_used("after measure runs (B)", gpu_used_bytes(), baseline_);
+    }
+    log_used("after session destruction (B)", gpu_used_bytes(), baseline_);
+}

--- a/tests/test_tensorrt_rtx_utils.cpp
+++ b/tests/test_tensorrt_rtx_utils.cpp
@@ -1,0 +1,338 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test_tensorrt_rtx_utils.h"
+
+#include <cuda_profiler_api.h>
+
+#include <chrono>
+#include <iostream>
+
+// =============================================================================
+// NVTX — compile with -DNVTX to enable; no-op stub otherwise.
+// =============================================================================
+#ifdef NVTX
+#include <nvtx3/nvtx3.hpp>
+#else
+namespace nvtx3 {
+struct scoped_range {
+    explicit scoped_range(const char*) {}
+    explicit scoped_range(const std::string&) {}
+};
+}  // namespace nvtx3
+#endif
+
+// =============================================================================
+// Session inspection
+// =============================================================================
+
+void describe_session(Ort::Session& session) {
+    Ort::AllocatorWithDefaultOptions cpu_alloc;
+
+    const auto input_count = session.GetInputCount();
+    std::cout << "Input count: " << input_count << "\n";
+    for (size_t i = 0; i < input_count; ++i) {
+        auto name  = session.GetInputNameAllocated(i, cpu_alloc);
+        auto info  = session.GetInputTypeInfo(i).GetTensorTypeAndShapeInfo();
+        std::cout << "  [" << i << "] " << name.get()
+                  << "  dtype=" << info.GetElementType() << "  shape=[ ";
+        for (auto s : info.GetShape()) std::cout << s << " ";
+        std::cout << "]\n";
+    }
+
+    const auto output_count = session.GetOutputCount();
+    std::cout << "Output count: " << output_count << "\n";
+    for (size_t i = 0; i < output_count; ++i) {
+        auto name  = session.GetOutputNameAllocated(i, cpu_alloc);
+        auto info  = session.GetOutputTypeInfo(i).GetTensorTypeAndShapeInfo();
+        std::cout << "  [" << i << "] " << name.get()
+                  << "  dtype=" << info.GetElementType() << "  shape=[ ";
+        for (auto s : info.GetShape()) std::cout << s << " ";
+        std::cout << "]\n";
+    }
+}
+
+// =============================================================================
+// Type / size helpers
+// =============================================================================
+
+size_t ONNXDtypeToBytes(ONNXTensorElementDataType t) {
+    switch (t) {
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:   return sizeof(float);
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:  return sizeof(double);
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:   return sizeof(uint8_t);
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:    return sizeof(int8_t);
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:  return sizeof(uint16_t);
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:   return sizeof(int16_t);
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16: return sizeof(uint16_t);
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:   return sizeof(int32_t);
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:  return sizeof(uint32_t);
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:   return sizeof(int64_t);
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:  return sizeof(uint64_t);
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:    return sizeof(bool);
+        default:
+            std::cerr << "ONNXDtypeToBytes: unexpected dtype " << t << "\n";
+            return 0;
+    }
+}
+
+size_t ORTValueToBytes(const Ort::Value& value) {
+    auto info = value.GetTensorTypeAndShapeInfo();
+    return info.GetElementCount() * ONNXDtypeToBytes(info.GetElementType());
+}
+
+// =============================================================================
+// run_with_cpu_bindings
+// =============================================================================
+
+void run_with_cpu_bindings(Ort::Session& session, int iterations) {
+    Ort::AllocatorWithDefaultOptions cpu_alloc;
+    Ort::IoBinding io_binding(session);
+
+    // Pre-allocate output tensors on CPU
+    const auto output_count = session.GetOutputCount();
+    std::vector<std::string> output_names;
+    std::vector<Ort::Value> output_values_flop, output_values_flip;
+    output_names.reserve(output_count);
+    output_values_flop.reserve(output_count);
+    output_values_flip.reserve(output_count);
+
+    for (size_t i = 0; i < output_count; ++i) {
+        auto name  = session.GetOutputNameAllocated(i, cpu_alloc);
+        auto info  = session.GetOutputTypeInfo(i);
+        auto shape_info = info.GetTensorTypeAndShapeInfo();
+        auto type = shape_info.GetElementType();
+        output_values_flop.emplace_back(
+            Ort::Value::CreateTensor(cpu_alloc, shape_info.GetShape().data(),
+                                     shape_info.GetShape().size(), type));
+        output_values_flip.emplace_back(
+            Ort::Value::CreateTensor(cpu_alloc, shape_info.GetShape().data(),
+                                     shape_info.GetShape().size(), shape_info.GetElementType()));
+        io_binding.BindOutput(name.get(), output_values_flop.back());
+        output_names.emplace_back(name.get());
+    }
+
+    CUDA_CHECK(cudaProfilerStart());
+    {
+        nvtx3::scoped_range r{"cpu bindings"};
+        auto start = std::chrono::high_resolution_clock::now();
+
+        for (int i = 0; i < iterations; ++i) {
+            // Re-bind inputs every iteration (zero-filled)
+            const auto input_count = session.GetInputCount();
+            for (size_t in = 0; in < input_count; ++in) {
+                auto name  = session.GetInputNameAllocated(in, cpu_alloc);
+                auto info  = session.GetInputTypeInfo(in);
+                auto shape_info = info.GetTensorTypeAndShapeInfo();
+                auto type = shape_info.GetElementType();
+                auto val   = Ort::Value::CreateTensor(
+                    cpu_alloc, shape_info.GetShape().data(),
+                    shape_info.GetShape().size(), type);
+                io_binding.BindInput(name.get(), val);
+            }
+
+            Ort::RunOptions run_options;
+            session.Run(run_options, io_binding);
+        }
+
+        auto stop = std::chrono::high_resolution_clock::now();
+        auto us   = std::chrono::duration_cast<std::chrono::microseconds>(stop - start).count();
+        std::cout << "CPU bindings per iteration [ms]: "
+                  << static_cast<float>(us) / static_cast<float>(iterations) / 1000.f
+                  << "\n";
+    }
+    CUDA_CHECK(cudaProfilerStop());
+}
+
+// =============================================================================
+// run_with_gpu_bindings
+// =============================================================================
+
+void run_with_gpu_bindings(Ort::Session& session, int iterations,
+                           cudaStream_t stream) {
+    const int device_id = 0;
+
+    Ort::MemoryInfo pinned_info("CudaPinned", OrtArenaAllocator, device_id,
+                                OrtMemTypeDefault);
+    Ort::Allocator cpu_alloc(session, pinned_info);
+
+    Ort::MemoryInfo cuda_info("Cuda", OrtArenaAllocator, device_id,
+                              OrtMemTypeDefault);
+    Ort::Allocator gpu_alloc(session, cuda_info);
+    OrtAllocator* gpu = gpu_alloc;
+
+    cudaStream_t upload_stream, download_stream;
+    CUDA_CHECK(cudaStreamCreate(&upload_stream));
+    CUDA_CHECK(cudaStreamCreate(&download_stream));
+
+    // Pre-allocate GPU output tensors (double-buffered: flop/flip)
+    const auto output_count = session.GetOutputCount();
+    std::vector<std::string> output_names;
+    std::vector<Ort::Value> out_flop, out_flip;
+    output_names.reserve(output_count);
+    out_flop.reserve(output_count);
+    out_flip.reserve(output_count);
+
+    Ort::IoBinding io_binding(session);
+    for (size_t i = 0; i < output_count; ++i) {
+        auto name = session.GetOutputNameAllocated(i, cpu_alloc);
+        auto info  = session.GetOutputTypeInfo(i);
+        auto shape_info = info.GetTensorTypeAndShapeInfo();
+        out_flop.emplace_back(Ort::Value::CreateTensor(
+            gpu, shape_info.GetShape().data(), shape_info.GetShape().size(), shape_info.GetElementType()));
+        out_flip.emplace_back(Ort::Value::CreateTensor(
+            gpu, shape_info.GetShape().data(), shape_info.GetShape().size(), shape_info.GetElementType()));
+        io_binding.BindOutput(name.get(), out_flop.back());
+        output_names.emplace_back(name.get());
+    }
+
+    // Pre-allocate GPU input tensors and CPU staging buffers
+    const auto input_count = session.GetInputCount();
+    std::vector<Ort::Value> in_gpu, in_cpu, out_cpu;
+    in_gpu.reserve(input_count);
+    in_cpu.reserve(input_count);
+
+    for (size_t i = 0; i < input_count; ++i) {
+        auto name = session.GetInputNameAllocated(i, cpu_alloc);
+        auto info = session.GetInputTypeInfo(i).GetTensorTypeAndShapeInfo();
+        in_gpu.emplace_back(Ort::Value::CreateTensor(
+            gpu, info.GetShape().data(), info.GetShape().size(), info.GetElementType()));
+        in_cpu.emplace_back(Ort::Value::CreateTensor(
+            cpu_alloc, info.GetShape().data(), info.GetShape().size(), info.GetElementType()));
+        io_binding.BindInput(name.get(), in_gpu.back());
+    }
+    for (size_t i = 0; i < output_count; ++i) {
+        auto name = session.GetOutputNameAllocated(i, cpu_alloc);
+        auto info = session.GetOutputTypeInfo(i).GetTensorTypeAndShapeInfo();
+        out_cpu.emplace_back(Ort::Value::CreateTensor(
+            cpu_alloc, info.GetShape().data(), info.GetShape().size(), info.GetElementType()));
+    }
+
+    cudaEvent_t ev_infer, ev_infer_cpu, ev_upload;
+    CUDA_CHECK(cudaEventCreate(&ev_infer));
+    CUDA_CHECK(cudaEventCreate(&ev_infer_cpu));
+    CUDA_CHECK(cudaEventCreate(&ev_upload));
+    // Mark as already done so the first iteration doesn't block
+    CUDA_CHECK(cudaEventRecord(ev_infer, stream));
+
+    CUDA_CHECK(cudaProfilerStart());
+    {
+        nvtx3::scoped_range r{"gpu bindings"};
+        auto start = std::chrono::high_resolution_clock::now();
+
+        for (int i = 0; i < iterations; ++i) {
+            auto& out_current = (i % 2) ? out_flip : out_flop;
+            const std::string label = (i % 2) ? "flip" : "flop";
+
+            // Upload inputs
+            {
+                nvtx3::scoped_range ru{"upload"};
+                for (size_t in = 0; in < in_gpu.size(); ++in) {
+                    CUDA_CHECK(cudaMemcpyAsync(
+                        in_gpu[in].GetTensorMutableRawData(),
+                        in_cpu[in].GetTensorRawData(),
+                        ORTValueToBytes(in_gpu[in]),
+                        cudaMemcpyHostToDevice, upload_stream));
+                }
+                CUDA_CHECK(cudaEventRecord(ev_upload, upload_stream));
+            }
+
+            for (size_t oi = 0; oi < output_names.size(); ++oi) {
+                io_binding.BindOutput(output_names[oi].c_str(), out_current[oi]);
+            }
+
+            CUDA_CHECK(cudaStreamWaitEvent(stream, ev_upload));
+            {
+                nvtx3::scoped_range ri{"inference"};
+                Ort::RunOptions run_options;
+                run_options.AddConfigEntry("disable_synchronize_execution_providers", "1");
+                session.Run(run_options, io_binding);
+                CUDA_CHECK(cudaEventRecord(ev_infer, stream));
+            }
+
+            // Throttle: wait for the previous inference before scheduling more work
+            CUDA_CHECK(cudaEventSynchronize(ev_infer_cpu));
+            CUDA_CHECK(cudaEventRecord(ev_infer_cpu, stream));
+
+            // Download outputs
+            {
+                nvtx3::scoped_range rd{"download " + label};
+                CUDA_CHECK(cudaStreamWaitEvent(download_stream, ev_infer));
+                for (size_t oi = 0; oi < out_current.size(); ++oi) {
+                    CUDA_CHECK(cudaMemcpyAsync(
+                        out_cpu[oi].GetTensorMutableRawData(),
+                        out_current[oi].GetTensorRawData(),
+                        ORTValueToBytes(out_flop[oi]),
+                        cudaMemcpyDeviceToHost, download_stream));
+                }
+            }
+        }
+
+        CUDA_CHECK(cudaStreamSynchronize(stream));
+        auto stop = std::chrono::high_resolution_clock::now();
+        auto us   = std::chrono::duration_cast<std::chrono::microseconds>(stop - start).count();
+        std::cout << "GPU bindings per iteration [ms]: "
+                  << static_cast<float>(us) / static_cast<float>(iterations) / 1000.f
+                  << "\n";
+    }
+    CUDA_CHECK(cudaProfilerStop());
+
+    CUDA_CHECK(cudaEventDestroy(ev_infer));
+    CUDA_CHECK(cudaEventDestroy(ev_infer_cpu));
+    CUDA_CHECK(cudaEventDestroy(ev_upload));
+    CUDA_CHECK(cudaStreamDestroy(upload_stream));
+    CUDA_CHECK(cudaStreamDestroy(download_stream));
+}
+
+// =============================================================================
+// IoBinding helper
+// =============================================================================
+
+Ort::IoBinding generate_io_binding(
+    Ort::Session& session,
+    std::map<std::string, std::vector<int64_t>> shape_overwrites,
+    OrtAllocator* allocator) {
+    Ort::IoBinding binding(session);
+    Ort::AllocatorWithDefaultOptions default_allocator;
+    if (allocator == nullptr) {
+        allocator = default_allocator;
+    }
+
+    for (size_t i = 0; i < session.GetInputCount(); ++i) {
+        auto name = session.GetInputNameAllocated(i, Ort::AllocatorWithDefaultOptions());
+        auto tensor_info = session.GetInputTypeInfo(i).GetTensorTypeAndShapeInfo();
+        auto shape = tensor_info.GetShape();
+        auto type = tensor_info.GetElementType();
+
+        auto it = shape_overwrites.find(name.get());
+        if (it != shape_overwrites.end()) {
+            shape = it->second;
+        } else {
+            for (auto& v : shape) {
+                if (v == -1) v = 1;
+            }
+        }
+
+        auto tensor = Ort::Value::CreateTensor(allocator,
+                                               shape.data(), shape.size(), type);
+        binding.BindInput(name.get(), tensor);
+    }
+
+    for (size_t i = 0; i < session.GetOutputCount(); ++i) {
+        auto name = session.GetOutputNameAllocated(i, Ort::AllocatorWithDefaultOptions());
+        binding.BindOutput(name.get(), default_allocator.GetInfo());
+    }
+    return binding;
+}

--- a/tests/test_tensorrt_rtx_utils.h
+++ b/tests/test_tensorrt_rtx_utils.h
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <onnxruntime_cxx_api.h>
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <map>
+#include <string>
+#include <vector>
+
+// =============================================================================
+// CUDA error checking
+// =============================================================================
+
+inline void cuda_error_check(cudaError_t err, const char* file, int line) {
+    if (err != cudaSuccess) {
+        ::fprintf(stderr, "CUDA ERROR at %s[%d]: %s\n", file, line,
+                  cudaGetErrorString(err));
+        abort();
+    }
+}
+
+#define CUDA_CHECK(err) cuda_error_check((err), __FILE__, __LINE__)
+
+// =============================================================================
+// Path / EP helpers
+// =============================================================================
+
+// Convert a filesystem path to the string type expected by the ORT C++ API
+// (wstring on Windows, string elsewhere).
+inline auto toOrtString(const std::filesystem::path& p) {
+#ifdef _WIN32
+    return p.wstring();
+#else
+    return p.string();
+#endif
+}
+
+// MODEL_FILE is injected as a compile definition by CMake.
+inline const std::filesystem::path kModelPath{MODEL_FILE};
+constexpr const char* kEpName = "NvTensorRTRTXExecutionProvider";
+
+// =============================================================================
+// ONNX Runtime version check (runtime DLL, not compile-time headers)
+// =============================================================================
+//
+// Returns true iff the currently-loaded onnxruntime.dll version parsed as
+// "major.minor[.patch]" is greater than or equal to (min_major, min_minor).
+// Writes the parsed version string to `version_out` for diagnostics.
+//
+// Intended for per-test gating (e.g. GTEST_SKIP) on features introduced in a
+// specific ORT release without affecting tests that work on older runtimes.
+inline bool ort_runtime_at_least(int min_major, int min_minor,
+                                 std::string& version_out) {
+    const OrtApiBase* base = OrtGetApiBase();
+    if (base == nullptr || base->GetVersionString == nullptr) {
+        version_out = "<unknown>";
+        return false;
+    }
+    const char* v = base->GetVersionString();
+    version_out = (v != nullptr) ? v : "<null>";
+    if (v == nullptr) return false;
+
+    int major = 0;
+    int minor = 0;
+    if (std::sscanf(v, "%d.%d", &major, &minor) < 2) return false;
+
+    if (major != min_major) return major > min_major;
+    return minor >= min_minor;
+}
+
+// Shorthand that swallows the version string.
+inline bool ort_runtime_at_least(int min_major, int min_minor) {
+    std::string unused;
+    return ort_runtime_at_least(min_major, min_minor, unused);
+}
+
+// Returns the subset of EP devices that belong to the TRT RTX EP.
+inline std::vector<Ort::ConstEpDevice> get_trt_rtx_devices(Ort::Env& env) {
+    std::vector<Ort::ConstEpDevice> result;
+    for (auto& device : env.GetEpDevices()) {
+        if (std::strcmp(device.EpName(), kEpName) == 0) {
+            result.push_back(device);
+        }
+    }
+    return result;
+}
+
+// =============================================================================
+// Session inspection
+// =============================================================================
+
+// Print input/output names, dtypes, and shapes to stdout.
+void describe_session(Ort::Session& session);
+
+// =============================================================================
+// Type / size helpers
+// =============================================================================
+
+size_t ONNXDtypeToBytes(ONNXTensorElementDataType element_type);
+size_t ORTValueToBytes(const Ort::Value& value);
+
+// =============================================================================
+// Inference runners
+// =============================================================================
+
+// Run `iterations` forward passes using CPU-side IoBinding.
+// Inputs are zero-initialised. Prints average per-iteration time to stdout.
+void run_with_cpu_bindings(Ort::Session& session, int iterations);
+
+// Run `iterations` forward passes using GPU-side IoBinding with async
+// upload/download streams. Prints average per-iteration time to stdout.
+void run_with_gpu_bindings(Ort::Session& session, int iterations,
+                           cudaStream_t stream);
+
+// =============================================================================
+// File helpers
+// =============================================================================
+
+inline void clearFileIfExists(const std::filesystem::path& path) {
+    if (std::filesystem::exists(path)) {
+        std::filesystem::remove(path);
+    }
+}
+
+// =============================================================================
+// IoBinding helper
+// =============================================================================
+
+// Create an IoBinding from session metadata. Allocates input tensors on CPU
+// (or with the given allocator). Dynamic dims (-1) are replaced with 1 unless
+// overridden via shape_overwrites.
+Ort::IoBinding generate_io_binding(
+    Ort::Session& session,
+    std::map<std::string, std::vector<int64_t>> shape_overwrites = {},
+    OrtAllocator* allocator = nullptr);

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,7 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "repository": "https://github.com/microsoft/vcpkg",
+    "baseline": "c82f74667287d3dc386bce81e44964370c91a289"
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "trt-rtx-ep",
+  "dependencies": [
+    {
+      "name": "protobuf",
+      "version>=": "3.21.12"
+    },
+    {
+      "name": "protobuf",
+      "host": true,
+      "version>=": "3.21.12"
+    },
+    "onnx",
+    "abseil"
+  ]
+}


### PR DESCRIPTION
Add test suite, ONNX compatibility passes, QDQ lowering, and vcpkg integration

- Add GoogleTest-based test suite covering basic, load/compile, EP context, options, shared mempool, and proto preprocessing scenarios
- Add ONNX compatibility lowering passes: clip bound, logical output, pooling dilation
- Add QDQ lowering and TRT proto preprocessing pipeline
- Add vcpkg manifest and configuration for dependency management
- Update execution provider, EP arena, and ONNX context model helper for new preprocessing and compatibility pipeline