### PR TITLE
fix: add missing None guard before using discovered EP device

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ for ep_device in ep_devices:
         trt_device = ep_device
         break
 
+if trt_device is None:
+    raise RuntimeError("TensorRT RTX EP device not found")
+
 # 3. Add EP device to session options with provider options
 session_options = ort.SessionOptions()
 session_options.add_provider_for_devices(


### PR DESCRIPTION
This PR corrects the documentation in `README.md`: add missing None guard before using discovered EP device.

## Changes
- `README.md`: add missing None guard before using discovered EP device.

## Details
```diff
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-for ep_device in ep_devices:
-    if ep_device.ep_name == "NvTensorRTRTXExecutionProvider":
-        trt_device = ep_device
-        break
-
-# 3. Add EP device to session options with provider options
-session_options = ort.SessionOptions()
+for ep_device in ep_devices:
+    if ep_device.ep_name == "NvTensorRTRTXExecutionProvider":
+        trt_device = ep_device
+        break
+
+if trt_device is None:
+    raise RuntimeError("TensorRT RTX EP device not found")
+
+# 3. Add EP device to session options with provider options
+session_options = ort.SessionOptions()
```

## Tests

> Let me know if you want tests added for this fix or not.